### PR TITLE
Remove close-port calls from app-templates

### DIFF
--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/support/env.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/support/env.js
@@ -29,7 +29,6 @@ module.exports = function() {
   this.After(function() {
     this.exocom && this.exocom.close()
     this.process && this.process.close()
-    this.process && this.process.closePort()
   })
 
 

--- a/exosphere-shared/templates/add-service/exoservice-es6/features/support/env.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6/features/support/env.js
@@ -6,6 +6,4 @@ module.exports = function() {
   this.setDefaultTimeout(1000)
   this.exocom && this.exocom.close()
   this.process && this.process.close()
-  this.process && this.process.closePort()
-
 }

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/support/env.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/support/env.ls
@@ -26,7 +26,6 @@ module.exports = ->
   @After ->
     @exocom?.close!
     @process?.close!
-    @process?.close-port!
 
 
   @registerHandler 'AfterFeatures', (_event, done) ->

--- a/exosphere-shared/templates/add-service/exoservice-ls/features/support/env.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls/features/support/env.ls
@@ -8,4 +8,3 @@ module.exports = ->
   @set-default-timeout 1000
   @exocom?.close!
   @process?.close!
-  @process?.close-port!


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
**partially** resolves #19 

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Removes the closePort calls after each scenario in the app-templates.

<!-- tag a few reviewers -->
@kevgo
