### PR TITLE
Fix exo-add tests

### DIFF
--- a/exo-add/features/exoservice-es6-mongodb.feature
+++ b/exo-add/features/exoservice-es6-mongodb.feature
@@ -20,8 +20,9 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
       version: 1.0.0
 
       services:
-        user-service:
-          location: ./user-service
+        public:
+          user-service:
+            location: ./user-service
       """
     And my application contains the file "user-service/service.yml" with the content:
       """
@@ -53,6 +54,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
 
       docker:
         link:
+          - 'mongo'
       """
     And my application contains the file "user-service/src/server.js"
     And my application contains the file "user-service/README.md" containing the text:

--- a/exo-add/features/exoservice-es6.feature
+++ b/exo-add/features/exoservice-es6.feature
@@ -19,8 +19,9 @@ Feature: scaffolding an ExoService written in ES6
       version: 1.0.0
 
       services:
-        users:
-          location: ./users
+        public:
+          users:
+            location: ./users
       """
     And my application contains the file "users/service.yml" with the content:
       """

--- a/exo-add/features/exoservice-ls-mongodb.feature
+++ b/exo-add/features/exoservice-ls-mongodb.feature
@@ -19,8 +19,9 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
       version: 1.0.0
 
       services:
-        user-service:
-          location: ./user-service
+        public:
+          user-service:
+            location: ./user-service
       """
     And my application contains the file "user-service/service.yml" with the content:
       """
@@ -52,6 +53,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
 
       docker:
         link:
+          - 'mongo'
       """
     And my application contains the file "user-service/src/server.ls"
     And my application contains the file "user-service/README.md" containing the text:

--- a/exo-add/features/exoservice-ls.feature
+++ b/exo-add/features/exoservice-ls.feature
@@ -19,8 +19,9 @@ Feature: scaffolding an ExoService written in LiveScript
       version: 1.0.0
 
       services:
-        users:
-          location: ./users
+        public:
+          users:
+            location: ./users
       """
     And my application contains the file "users/service.yml" with the content:
       """

--- a/exo-add/features/htmlserver-express-es6.feature
+++ b/exo-add/features/htmlserver-express-es6.feature
@@ -18,8 +18,9 @@ Feature: scaffolding an ExpressJS html server written in ES6
       version: 1.0.0
 
       services:
-        html-server:
-          location: ./html-server
+        public:
+          html-server:
+            location: ./html-server
       """
     And my application contains the file "html-server/service.yml" with the content:
       """
@@ -62,8 +63,9 @@ Feature: scaffolding an ExpressJS html server written in ES6
       version: 1.0.0
 
       services:
-        html-server:
-          location: ./html-server
+        public:
+          html-server:
+            location: ./html-server
       """
     And my application contains the file "html-server/service.yml" with the content:
       """

--- a/exo-add/features/htmlserver-express-livescript.feature
+++ b/exo-add/features/htmlserver-express-livescript.feature
@@ -18,8 +18,9 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
       version: 1.0.0
 
       services:
-        html-server:
-          location: ./html-server
+        public:
+          html-server:
+            location: ./html-server
       """
     And my application contains the file "html-server/service.yml" with the content:
       """

--- a/exo-add/features/without-arguments.feature
+++ b/exo-add/features/without-arguments.feature
@@ -23,8 +23,9 @@ Feature: interactive scaffolding
       version: 1.0.0
 
       services:
-        web:
-          location: ./web
+        public:
+          web:
+            location: ./web
       """
     And my application contains the file "web/service.yml" containing the text:
       """

--- a/exosphere-shared/bin/setup
+++ b/exosphere-shared/bin/setup
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 npm install --loglevel error --depth 0
+node_modules/o-tools-livescript/bin/build


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Some feature files in `exo-add` were out of date. More importantly, exosphere-shared wasn't being built in its setup script, hence the Travis error complaining that it couldn't find the exosphere-shared module.

<!-- tag a few reviewers -->
@kevgo 
