### PR TITLE
Remove exocom container if exo-run was executed

### DIFF
--- a/cli/features/steps/steps.ls
+++ b/cli/features/steps/steps.ls
@@ -140,6 +140,7 @@ module.exports = ->
       | 'exo create service'     => 'We are about to create a new Exosphere service'
       | 'exo add'                => 'We are about to add a new Exosphere service to the application'
     @process.wait expected-text, ~>
+      # Need to remove exocom dontainer to clear ports for future tests
       DockerHelper.remove-container \exocom if expected-text is \exo-run
       done!
 

--- a/cli/features/steps/steps.ls
+++ b/cli/features/steps/steps.ls
@@ -3,7 +3,7 @@ require! {
   'chai' : {expect}
   'dim-console'
   'fs-extra' : fs
-  '../../../exosphere-shared' : {call-args}
+  '../../../exosphere-shared' : {call-args, DockerHelper}
   'jsdiff-console'
   'nitroglycerin' : N
   'observable-process' : ObservableProcess
@@ -139,7 +139,9 @@ module.exports = ->
       | 'exo create application' => 'We are about to create a new Exosphere application'
       | 'exo create service'     => 'We are about to create a new Exosphere service'
       | 'exo add'                => 'We are about to add a new Exosphere service to the application'
-    @process.wait expected-text, done
+    @process.wait expected-text, ~>
+      DockerHelper.remove-container \exocom if expected-text is \exo-run
+      done!
 
 
   @Then /^my workspace contains the file "([^"]*)" with content:$/, (filename, expected-content, done) ->


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Previously, when running `bin/spec` in the `cli` subrepo, there would be an error in the tutorial feature because port 8000 was being used by an exocom docker container that was started in the `abbreviations.feature`. Since the process started by `abbreviations.feature` was killed using `kill-child-processes` of exosphere-shared, it does not give time for exo-run to shut down correctly and remove its docker containers. This change accounts for that. 
 
<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
