### PR TITLE
Always run exosphere-shared on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - cd $TRAVIS_REPO_SLUG
   - git checkout $TRAVIS_BRANCH
   - curl --output morula --location --fail https://github.com/Originate/morula/releases/download/0.1/morula-linux-amd64 && chmod +x morula
-
+  - pwd
+  - ls
 
 install:
   - './exosphere-shared/bin/setup'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 
 
 install:
+  - './exosphere-shared/bin/setup'
   - 'if [ "$TRAVIS_BRANCH" == "master" ]; then ./morula all bin/setup; else echo skipping; fi'
   - 'if [ "$TRAVIS_BRANCH" != "master" ]; then ./morula changed bin/setup; else echo skipping; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
   - ls
 
 install:
+  - pwd
+  - ls
   - './exosphere-shared/bin/setup'
   - 'if [ "$TRAVIS_BRANCH" == "master" ]; then ./morula all bin/setup; else echo skipping; fi'
   - 'if [ "$TRAVIS_BRANCH" != "master" ]; then ./morula changed bin/setup; else echo skipping; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - git checkout $TRAVIS_BRANCH
   - curl --output morula --location --fail https://github.com/Originate/morula/releases/download/0.1/morula-linux-amd64 && chmod +x morula
 
+
 install:
   - 'cd ./exosphere-shared'
   - './bin/setup'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   - 'cd ./exosphere-shared'
   - './bin/setup'
-  - 'cd $TRAVIS_REPO_SLUG'
+  - 'cd ..'
   - 'if [ "$TRAVIS_BRANCH" == "master" ]; then ./morula all bin/setup; else echo skipping; fi'
   - 'if [ "$TRAVIS_BRANCH" != "master" ]; then ./morula changed bin/setup; else echo skipping; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,11 @@ before_install:
   - cd $TRAVIS_REPO_SLUG
   - git checkout $TRAVIS_BRANCH
   - curl --output morula --location --fail https://github.com/Originate/morula/releases/download/0.1/morula-linux-amd64 && chmod +x morula
-  - pwd
-  - ls
 
 install:
-  - pwd
-  - ls
-  - './exosphere-shared/bin/setup'
+  - 'cd ./exosphere-shared'
+  - './bin/setup'
+  - 'cd $TRAVIS_REPO_SLUG'
   - 'if [ "$TRAVIS_BRANCH" == "master" ]; then ./morula all bin/setup; else echo skipping; fi'
   - 'if [ "$TRAVIS_BRANCH" != "master" ]; then ./morula changed bin/setup; else echo skipping; fi'
 

--- a/morula.yml
+++ b/morula.yml
@@ -1,5 +1,5 @@
 before-all: ""
 after-all: ""
-always: "exosphere-shared"
+always: ""
 never: ""
 color: true

--- a/morula.yml
+++ b/morula.yml
@@ -1,5 +1,5 @@
 before-all: ""
 after-all: ""
-always: ""
+always: "exosphere-shared"
 never: ""
 color: true


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->


<!-- a short description of the change in addition to what is already mentioned in the issue above -->
When changes to sub-projects (such as `exo-run`, `exo-setup`) are made, Morula will run tests for only that sub-project. This means `exosphere-shared` isn't built and cannot be used. This PR always runs exosphere-shared on Travis.
<!-- tag a few reviewers -->
@kevgo @trushton @martinjaime 
