### PR TITLE
Add setup step when starting applications in exo-run tests

### DIFF
--- a/exo-run/features/steps/steps.ls
+++ b/exo-run/features/steps/steps.ls
@@ -27,13 +27,14 @@ module.exports = ->
   @Given /^a running "([^"]*)" application$/ timeout: 600_000, (@app-name, done) ->
     @checkout-app @app-name
     app-dir := path.join process.cwd!, 'tmp', @app-name
-    command = \exo-run
-    if process.platform is 'win32' then command += '.cmd'
-    @process = new ObservableProcess(call-args(path.join process.cwd!, 'bin', command),
-                                     cwd: app-dir,
-                                     stdout: dim-console.process.stdout
-                                     stderr: dim-console.process.stderr)
-    done!
+    @setup-app app-dir, ~>
+      command = \exo-run
+      if process.platform is 'win32' then command += '.cmd'
+      @process = new ObservableProcess(call-args(path.join process.cwd!, 'bin', command),
+                                       cwd: app-dir,
+                                       stdout: dim-console.process.stdout
+                                       stderr: dim-console.process.stderr)
+      done!
 
 
   @When /^running "([^"]*)" in this application's directory$/ timeout: 600_000, (command, done) ->

--- a/exo-run/features/support/world.ls
+++ b/exo-run/features/support/world.ls
@@ -1,5 +1,7 @@
 require! {
+  'dim-console'
   'fs-extra' : fs
+  'observable-process' : ObservableProcess
   'path'
 }
 
@@ -10,6 +12,14 @@ World = !->
     app-dir = path.join process.cwd!, 'tmp', app-name
     fs.empty-dir-sync app-dir
     fs.copy-sync path.join(process.cwd!, '..' 'exosphere-shared' 'example-apps', app-name), app-dir
+
+
+  @setup-app = (app-dir, done) ->
+    new ObservableProcess(path.join(process.cwd!, '..' 'exo-setup' 'bin', 'exo-setup'),
+                          cwd: app-dir
+                          stdout: dim-console.process.stdout
+                          stderr: dim-console.process.stderr)
+      ..on 'ended', done
 
 
 

--- a/exosphere-shared/example-apps/crashing-service/runner/server
+++ b/exosphere-shared/example-apps/crashing-service/runner/server
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 echo 'running ...'
+sleep 100000

--- a/exosphere-shared/example-apps/crashing-service/runner/server
+++ b/exosphere-shared/example-apps/crashing-service/runner/server
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
 echo 'running ...'
-read test


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Adds a step after checking out the application to run `exo-setup`. This is needed in case a user does not have any of the docker images before running the spec test for `exo-run`. We had not encountered this yet as we had tested exo-setup beforehand which took care of this.

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
