### PR TITLE
Implement exosphere-shared method in Docker

### DIFF
--- a/exo-deploy/src/docker/docker.ls
+++ b/exo-deploy/src/docker/docker.ls
@@ -39,7 +39,9 @@ class Docker
             @_run!
 
   _run: ~>
+    exosphere-shared-dir = path.normalize("#{__dirname}/../../../exosphere-shared")
     flags = "-v #{process.cwd!}:/var/app:ro " +
+            "-v #{exosphere-shared-dir}:/usr/src/exosphere-shared:ro " + # how to make sure exosphere-shared is compiled?
             "--env AWS_ACCESS_KEY_ID=#{process.env.AWS_ACCESS_KEY_ID} " +
             "--env AWS_SECRET_ACCESS_KEY=#{process.env.AWS_SECRET_ACCESS_KEY} "
     new ObservableProcess("docker run #{flags} originate/exo-deploy:#{@version}",

--- a/exo-deploy/src/docker/docker.ls
+++ b/exo-deploy/src/docker/docker.ls
@@ -39,9 +39,7 @@ class Docker
             @_run!
 
   _run: ~>
-    exosphere-shared-dir = path.normalize("#{__dirname}/../../../exosphere-shared")
     flags = "-v #{process.cwd!}:/var/app:ro " +
-            "-v #{exosphere-shared-dir}:/usr/src/exosphere-shared:ro " + # how to make sure exosphere-shared is compiled?
             "--env AWS_ACCESS_KEY_ID=#{process.env.AWS_ACCESS_KEY_ID} " +
             "--env AWS_SECRET_ACCESS_KEY=#{process.env.AWS_SECRET_ACCESS_KEY} "
     new ObservableProcess("docker run #{flags} originate/exo-deploy:#{@version}",

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -1,6 +1,6 @@
 require! {
   'async'
-  '../../../exosphere-shared' : {compile-service-messages}
+  '/usr/src/exosphere-shared' : {compile-service-messages}
   'fs-extra' : fs
   'handlebars'
   'path'

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -153,18 +153,18 @@ class AwsTerraformFileBuilder
       ]
       environment: [
         name: 'SERVICE_MESSAGES'
-        value: @_compile-service-messages(@app-config, '/var/app') |> JSON.stringify
+        value: @_compile-service-messages |> JSON.stringify
       ]
     ]
     target-path = path.join @terraform-path, 'exocom-container-definition.json'
     fs.write-file-sync target-path, JSON.stringify(container-definition, null, 2)
 
 
-  _compile-service-messages: (app-config, base-path) ->
+  _compile-service-messages: ->
     service-messages = []
-    for type of app-config.services
-      for service-name, service-data of app-config.services["#{type}"]
-        service-config = require path.join(base-path ? process.cwd!, service-data.location, 'service.yml')
+    for type of @app-config.services
+      for service-name, service-data of @app-config.services["#{type}"]
+        service-config = require path.join('/var/app', service-data.location, 'service.yml')
         service-messages.push do
           {
             name: service-name

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -1,6 +1,5 @@
 require! {
   'async'
-  '/usr/src/exosphere-shared' : {compile-service-messages}
   'fs-extra' : fs
   'handlebars'
   'path'
@@ -154,11 +153,26 @@ class AwsTerraformFileBuilder
       ]
       environment: [
         name: 'SERVICE_MESSAGES'
-        value: compile-service-messages(@app-config, '/var/app') |> JSON.stringify
+        value: @_compile-service-messages(@app-config, '/var/app') |> JSON.stringify
       ]
     ]
     target-path = path.join @terraform-path, 'exocom-container-definition.json'
     fs.write-file-sync target-path, JSON.stringify(container-definition, null, 2)
+
+
+  _compile-service-messages: (app-config, base-path) ->
+    service-messages = []
+    for type of app-config.services
+      for service-name, service-data of app-config.services["#{type}"]
+        service-config = require path.join(base-path ? process.cwd!, service-data.location, 'service.yml')
+        service-messages.push do
+          {
+            name: service-name
+            receives: service-config.messages.receives
+            sends: service-config.messages.sends
+            namespace: service-data.namespace
+          }
+    service-messages
 
 
 module.exports = AwsTerraformFileBuilder

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -166,12 +166,10 @@ class AwsTerraformFileBuilder
       for service-name, service-data of @app-config.services["#{type}"]
         service-config = require path.join('/var/app', service-data.location, 'service.yml')
         service-messages.push do
-          {
-            name: service-name
-            receives: service-config.messages.receives
-            sends: service-config.messages.sends
-            namespace: service-data.namespace
-          }
+          name: service-name
+          receives: service-config.messages.receives
+          sends: service-config.messages.sends
+          namespace: service-data.namespace
     service-messages
 
 


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
We cannot require `exopshere-shared` as a module now that we are using Webpack. Instead of mounting `exosphere-shared` into Docker to use just one method, we are copying that code over instead.

<!-- tag a few reviewers -->

@kevgo @trushton @martinjaime 