### PR TITLE
Use variable ami id

### DIFF
--- a/exo-deploy/templates/aws-terraform/exocom/cluster/main.tf
+++ b/exo-deploy/templates/aws-terraform/exocom/cluster/main.tf
@@ -3,6 +3,7 @@ variable "instance_type" {}
 variable "security_groups" {}
 variable "iam_instance_profile" {}
 variable "subnet_id" {}
+variable "ami_id" {}
 
 output "cluster_id" { value = "${aws_ecs_cluster.cluster.id}" }
 output "exocom_ip"  { value = "${aws_instance.exocom.public_ip}" }
@@ -13,7 +14,7 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 resource "aws_instance" "exocom" {
-  ami = "ami-56ed4936"
+  ami = "${var.ami_id}"
   subnet_id = "${var.subnet_id}"
   instance_type = "${var.instance_type}"
   iam_instance_profile = "${var.iam_instance_profile}"

--- a/exo-deploy/templates/aws-terraform/main.tf
+++ b/exo-deploy/templates/aws-terraform/main.tf
@@ -27,6 +27,19 @@ resource "aws_route53_zone" "hosted_zone" {
 }
 
 
+data "aws_ami" "ecs_ami" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-*-amazon-ecs-optimized"]
+  }
+}
+
+
 module "exocom-cluster" {
   source = "./exocom/cluster"
 
@@ -35,6 +48,7 @@ module "exocom-cluster" {
   instance_type = "t2.micro"
   security_groups = "${aws_security_group.public.id}"
   subnet_id = "${module.vpc.public_subnet_id}"
+  ami_id = "${data.aws_ami.ecs_ami.id}"
 }
 
 
@@ -46,6 +60,7 @@ module "public-cluster" {
   instance_type = "{{publicClusterSize}}"
   security_groups = "${aws_security_group.public.id}"
   subnet_ids = "${module.vpc.public_subnet_id}"
+  ami_id = "${data.aws_ami.ecs_ami.id}"
 }
 
 module "private-cluster" {
@@ -56,4 +71,5 @@ module "private-cluster" {
   instance_type = "{{privateClusterSize}}"
   security_groups = "${aws_security_group.public.id}"
   subnet_ids = "${module.vpc.private_subnet_id}"
+  ami_id = "${data.aws_ami.ecs_ami.id}"
 }

--- a/exo-deploy/templates/aws-terraform/private-services/cluster/main.tf
+++ b/exo-deploy/templates/aws-terraform/private-services/cluster/main.tf
@@ -3,6 +3,7 @@ variable "instance_type" {}
 variable "security_groups" {}
 variable "iam_instance_profile" {}
 variable "subnet_ids" {}
+variable "ami_id" {}
 
 output "cluster_id" { value = "${aws_ecs_cluster.cluster.id}" }
 
@@ -15,7 +16,7 @@ resource "aws_ecs_cluster" "cluster" {
 resource "aws_launch_configuration" "cluster" {
   name                 = "exosphere-${var.name}-launch-config"
   iam_instance_profile = "${var.iam_instance_profile}"
-  image_id             = "ami-56ed4936"
+  image_id             = "${var.ami_id}"
   instance_type        = "${var.instance_type}"
   security_groups      = ["${var.security_groups}"]
   user_data            = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.cluster.name} > /etc/ecs/ecs.config"

--- a/exo-deploy/templates/aws-terraform/public-services/cluster/main.tf
+++ b/exo-deploy/templates/aws-terraform/public-services/cluster/main.tf
@@ -3,6 +3,7 @@ variable "instance_type" {}
 variable "security_groups" {}
 variable "iam_instance_profile" {}
 variable "subnet_ids" {}
+variable "ami_id" {}
 
 output "cluster_id" { value = "${aws_ecs_cluster.cluster.id}" }
 
@@ -15,7 +16,7 @@ resource "aws_ecs_cluster" "cluster" {
 resource "aws_launch_configuration" "cluster" {
   name                 = "exosphere-${var.name}-launch-config"
   iam_instance_profile = "${var.iam_instance_profile}"
-  image_id             = "ami-56ed4936"
+  image_id             = "${var.ami_id}"
   instance_type        = "${var.instance_type}"
   security_groups      = ["${var.security_groups}"]
   user_data            = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.cluster.name} > /etc/ecs/ecs.config"


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->


<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Use variable ami id instead of hard coded version so that we will always use most up to date versions.


<!-- tag a few reviewers -->
@kevgo 
