### PR TITLE
Build exo-setup in exo-run tests

### DIFF
--- a/exo-run/bin/features
+++ b/exo-run/bin/features
@@ -2,6 +2,8 @@
 set -e
 
 node_modules/o-tools-livescript/bin/build
+cd ../exo-setup && bin/setup && node_modules/.bin/build
+cd ../exo-run
 if [ "$#" == "0" ]; then
   cucumber-js --strict
 else

--- a/exo-run/bin/features
+++ b/exo-run/bin/features
@@ -2,8 +2,7 @@
 set -e
 
 node_modules/o-tools-livescript/bin/build
-cd ../exo-setup && bin/setup && node_modules/.bin/build
-cd ../exo-run
+(cd ../exo-setup && bin/setup && node_modules/.bin/build)
 if [ "$#" == "0" ]; then
   cucumber-js --strict
 else

--- a/exo-run/bin/spec
+++ b/exo-run/bin/spec
@@ -2,6 +2,8 @@
 set -e
 
 node_modules/o-tools-livescript/bin/build
+cd ../exo-setup && bin/setup && node_modules/.bin/build
+cd ../exo-run
 if [ "$#" == "0" ]; then
   node_modules/o-tools/bin/lint
   cucumber-js --strict

--- a/exo-run/bin/spec
+++ b/exo-run/bin/spec
@@ -2,8 +2,7 @@
 set -e
 
 node_modules/o-tools-livescript/bin/build
-cd ../exo-setup && bin/setup && node_modules/.bin/build
-cd ../exo-run
+(cd ../exo-setup && bin/setup && node_modules/.bin/build)
 if [ "$#" == "0" ]; then
   node_modules/o-tools/bin/lint
   cucumber-js --strict

--- a/exo-run/bin/spec_ci
+++ b/exo-run/bin/spec_ci
@@ -9,4 +9,6 @@ docker pull exospheredev/web-server
 docker pull exospheredev/mongo-service
 docker pull exospheredev/crasher
 docker pull exospheredev/runner
+cd ../exo-setup && bin/setup && node_modules/.bin/build
+cd ../exo-run
 node_modules/.bin/cucumber-js --tags ~@todo --format pretty

--- a/exo-run/bin/spec_ci
+++ b/exo-run/bin/spec_ci
@@ -9,6 +9,5 @@ docker pull exospheredev/web-server
 docker pull exospheredev/mongo-service
 docker pull exospheredev/crasher
 docker pull exospheredev/runner
-cd ../exo-setup && bin/setup && node_modules/.bin/build
-cd ../exo-run
+(cd ../exo-setup && bin/setup && node_modules/.bin/build)
 node_modules/.bin/cucumber-js --tags ~@todo --format pretty


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #45 

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Since `exo-run` uses `exo-setup` in its tests, we must run setup in that directory before running the tests.

<!-- tag a few reviewers -->
@kevgo @trushton @martinjaime 
