### PR TITLE
Replace require-yaml with yaml.safe-load

### DIFF
--- a/exo-deploy/src/cli.ls
+++ b/exo-deploy/src/cli.ls
@@ -2,13 +2,15 @@ require! {
   'chalk' : {cyan, green}
   './docker/docker' : Docker
   'exosphere-shared' : {Logger}
+  'fs'
   'inquirer'
+  'js-yaml' : yaml
   'path'
 }
 
 module.exports = ->
   command-flag = process.argv[2]
-  app-config = require path.join(process.cwd!, 'application.yml')
+  app-config = yaml.safe-load fs.read-file-sync(path.join(process.cwd!, 'application.yml'), 'utf8')
   logger = new Logger
   docker = new Docker app-config, logger
   if (command-flag is '--nuke') or (command-flag is '--teardown')

--- a/exo-deploy/src/deploy.ls
+++ b/exo-deploy/src/deploy.ls
@@ -6,7 +6,7 @@ require! {
 }
 
 command-flag = process.argv[2]
-app-config = require '/var/app/application.yml'
+app-config = yaml.safe-load fs.read-file-sync('/var/app/application.yml', 'utf8')
 deployer = new AppDeployer app-config
 if command-flag is '--nuke' then
   deployer.teardown nuke: yes, (err) ->

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -3,7 +3,6 @@ require! {
   'fs-extra' : fs
   'handlebars'
   'path'
-  'require-yaml'
 }
 
 class AwsTerraformFileBuilder
@@ -74,7 +73,7 @@ class AwsTerraformFileBuilder
 
   _generate-services: (type) ->
     for service-name, service-data of @app-config.services["#{type}"]
-      service-config = require path.join('/var/app', service-data.location, 'service.yml')
+      service-config = yaml.safe-load fs.read-file-sync(path.join('/var/app', service-data.location, 'service.yml'), 'utf8')
       @_build-service-container-definition service-name, (@_get-image-name service-data), service-config
       data =
         name: service-name
@@ -166,7 +165,7 @@ class AwsTerraformFileBuilder
 
 
   _get-image-name: (service-data) ->
-    service-config = require path.join('/var/app', service-data.location, 'service.yml')
+    service-config = yaml.safe-load fs.read-file-sync(path.join('/var/app', service-data.location, 'service.yml'), 'utf8')
     "#{service-config.author}/#{service-config.title |> (.replace /\s/g, '-')}"
     #TODO: get image name if location is docker on dockerhub
 
@@ -175,7 +174,7 @@ class AwsTerraformFileBuilder
     service-messages = []
     for type of @app-config.services
       for service-name, service-data of @app-config.services["#{type}"]
-        service-config = require path.join('/var/app', service-data.location, 'service.yml')
+        service-config = yaml.safe-load fs.read-file-sync(path.join('/var/app', service-data.location, 'service.yml'), 'utf8')
         service-messages.push do
           name: service-name
           receives: service-config.messages.receives


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Webpack does not seem to like require statements as expressions (like when using require-yaml to import yaml files), this change resolves issues related to that in the exo-deploy sub-repo

<!-- tag a few reviewers -->
@kevgo @martinjaime @hugobho 
