### PR TITLE
Remove 'service replies' step (exo-run)

### DIFF
--- a/exo-run/features/run.feature
+++ b/exo-run/features/run.feature
@@ -31,7 +31,6 @@ Feature: running Exosphere applications
       | users.created | users   | web       |
     When the web service broadcasts a "users.list" message
     Then the "mongo" service receives a "mongo.list" message
-    And the "mongo" service replies with a "mongo.listed" message
     And the "web" service receives a "users.listed" message
 
 

--- a/exo-run/features/steps/steps.ls
+++ b/exo-run/features/steps/steps.ls
@@ -115,7 +115,3 @@ module.exports = ->
 
   @Then /^the "([^"]*)" service receives a "([^"]*)" message$/ (service, message, done) ->
     @process.wait "'#{service}' service received message '#{message}'", done
-
-
-  @Then /^the "([^"]*)" service replies with a "([^"]*)" message$/ (arg1, arg2, done) ->
-    done!


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves [Originate/exosphere-sdk#66](https://github.com/Originate/exosphere-sdk/issues/66)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->Removing the 'service replies' step entirely, seeing as the step that would always reasonably follow it, `service xxx receives message yyy`, implies that the correct reply was sent. 

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
