### PR TITLE
Use service.yml title as docker image name

### DIFF
--- a/exo-run/package.json
+++ b/exo-run/package.json
@@ -6,6 +6,7 @@
     "async": "2.1.4",
     "chalk": "1.1.3",
     "chokidar": "1.6.1",
+    "dashify": "0.2.2",
     "js-yaml": "3.7.0",
     "nitroglycerin": "1.1.2",
     "observable-process": "3.2.0",

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -1,6 +1,7 @@
 require! {
   'child_process'
   'chokidar' : {watch}
+  'dashify'
   './docker-runner' : DockerRunner
   'events' : {EventEmitter}
   '../../exosphere-shared' : {call-args, DockerHelper}
@@ -23,7 +24,7 @@ class ServiceRunner extends EventEmitter
   start: (done) ~>
     @docker-config =
       author: @service-config.author
-      image: path.basename @config.root
+      image: dashify @service-config.title
       start-command: @service-config.startup.command
       start-text: @service-config.startup['online-text']
       cwd: @config.root

--- a/exo-setup/features/setup.feature
+++ b/exo-setup/features/setup.feature
@@ -21,7 +21,7 @@ Feature: Setup of Exosphere applications
       | mongo-service/Dockerfile |
       | web-server/Dockerfile    |
     And it has acquired the Docker images:
-      | dashboard     |
-      | mongo-service |
-      | web-server    |
-      | exocom        |
+      | dashboard-server       |
+      | test-mongo-db-server   |
+      | test-app-web-server    |
+      | exocom                 |

--- a/exo-setup/package.json
+++ b/exo-setup/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "async": "2.1.4",
     "chalk": "1.1.3",
+    "dashify": "0.2.2",
     "js-yaml": "3.7.0",
     "observable-process": "3.2.0",
     "prelude-ls": "1.1.2",

--- a/exo-setup/package.json
+++ b/exo-setup/package.json
@@ -9,7 +9,6 @@
     "js-yaml": "3.7.0",
     "observable-process": "3.2.0",
     "prelude-ls": "1.1.2",
-    "require-yaml": "0.0.1",
     "shelljs": "0.7.5"
   },
   "description": "The 'exo-setup' command",

--- a/exo-setup/src/docker-setup.ls
+++ b/exo-setup/src/docker-setup.ls
@@ -25,8 +25,8 @@ class DockerSetup extends EventEmitter
 
 
   _build-docker-image: (done) ~>
-    new ObservableProcess(call-args(DockerHelper.get-build-command author: @service-config.author, name: dashify @service-config.title),
-                          cwd: @config.root,
+    new ObservableProcess(call-args(DockerHelper.get-build-command author: @service-config.author, name: dashify(@service-config.title)),
+                          cwd: @config.root
                           stdout: {@write}
                           stderr: {@write})
       ..on 'ended', (exit-code, killed) ~>

--- a/exo-setup/src/docker-setup.ls
+++ b/exo-setup/src/docker-setup.ls
@@ -1,13 +1,12 @@
 require! {
   'chalk' : {red}
+  'dashify'
   'events' : {EventEmitter}
   '../../exosphere-shared' : {templates-path, call-args, DockerHelper}
   'fs'
   'js-yaml' : yaml
   'observable-process' : ObservableProcess
   'path'
-  'prelude-ls' : {last}
-  'require-yaml'
   'shelljs' : {cp}
 }
 
@@ -26,8 +25,7 @@ class DockerSetup extends EventEmitter
 
 
   _build-docker-image: (done) ~>
-    service-name = @config.root.split path.sep |> last
-    new ObservableProcess(call-args(DockerHelper.get-build-command author: @service-config.author, name: service-name),
+    new ObservableProcess(call-args(DockerHelper.get-build-command author: @service-config.author, name: dashify @service-config.title),
                           cwd: @config.root,
                           stdout: {@write}
                           stderr: {@write})

--- a/exo-setup/src/service-setup.ls
+++ b/exo-setup/src/service-setup.ls
@@ -18,7 +18,7 @@ class ServiceSetup extends EventEmitter
   start: (done) ~>
     @logger.log name: @name, text: "starting setup"
     new ObservableProcess(call-args(normalize-path @service-config.setup),
-                          cwd: @config.root,
+                          cwd: @config.root
                           stdout: {@write}
                           stderr: {@write})
       ..on 'ended', (exit-code, killed) ~>


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #13

<!-- a short description of the change in addition to what is already mentioned in the issue above -->Using dashify to make the title field of `service.yml` compatible as a docker image name. This name reflects what will be run in exo-run and deployed to dockerhub with exo-deploy. 

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 