### PR TITLE
Check message name in template test def (exosphere-shared)

### DIFF
--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/list.feature
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/list.feature
@@ -11,7 +11,7 @@ Feature: Listing all _____modelName_____s
 
   Scenario: no _____modelName_____s exist in the database
     When receiving the message "_____modelName_____.list"
-    Then the service replies with "_____modelName_____s.listing" and the payload:
+    Then the service replies with "_____modelName_____.listing" and the payload:
       """
       []
       """

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/steps/steps.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/steps/steps.js
@@ -90,6 +90,7 @@ module.exports = function() {
     var expectedPayload = null
     eval(`expectedPayload = ${payload}`)
     this.exocom.onReceive( () => {
+      expect(this.exocom.receivedMessages[0].name).to.equal(message)
       actualPayload = this.exocom.receivedMessages[0].payload
       jsDiff(this.removeIds(actualPayload),
              this.removeIds(expectedPayload),

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/list.feature
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/list.feature
@@ -11,7 +11,7 @@ Feature: Listing all _____modelName_____s
 
   Scenario: no _____modelName_____s exist in the database
     When sending the message "_____modelName_____.list"
-    Then the service replies with "_____modelName_____s.listing" and the payload:
+    Then the service replies with "_____modelName_____.listing" and the payload:
       """
       []
       """

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/steps/steps.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/steps/steps.ls
@@ -71,5 +71,6 @@ module.exports = ->
   @Then /^the service replies with "([^"]*)" and the payload:$/, (message, payload, done) ->
     expected-payload = eval livescript.compile payload, bare: true
     @exocom.on-receive ~>
+      expect(@exocom.received-messages[0].name).to.equal message
       actual-payload = @exocom.received-messages[0].payload
       jsdiff-console @remove-ids(actual-payload), @remove-ids(expected-payload), done


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves [Originate/exosphere-sdk#195](https://github.com/Originate/exosphere-sdk/issues/195)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
The modified step was not checking that the correct message name was being sent to and received by exocom. Once this check was added, it was noticed that the `list.feature` itself had an additional 's' in the message name that it was expecting, causing the message-name check to fail.

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
