### PR TITLE
Read online-text from service.yml (exosphere-shared)

### DIFF
--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -61,7 +61,7 @@ Feature: Following the tutorial
       """
     And my application contains the file "html-server/service.yml" with the content:
     """
-    name: html-server
+    title: html-server
     description: serves HTML UI for the test app
     author: test-author
 
@@ -102,7 +102,7 @@ Feature: Following the tutorial
     And waiting until the process ends
     Then my application contains the file "todo-service/service.yml" with the content:
       """
-      name: todo-service
+      title: todo-service
       description: stores the todo entries
       author: test-author
 
@@ -202,7 +202,7 @@ Feature: Following the tutorial
       """
     And the file "html-server/service.yml":
       """
-      name: html-server
+      title: html-server
       description: serves HTML UI for the test app
 
       setup: npm install --loglevel error --depth 0

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-es6/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-ls/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/app/index.js
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/app/index.js
@@ -3,8 +3,11 @@
 // It parses the command line and instantiates the two servers for this app:
 const {cyan, dim, green, red} = require('chalk')
 const ExoRelay = require('exorelay');
+const fs = require('fs');
+const yaml = require('js-yaml');
 const N = require('nitroglycerin');
 const {name, version} = require('../package.json')
+const path = require('path');
 const WebServer = require('./web-server')
 const port = process.env.PORT || 3000
 
@@ -35,6 +38,7 @@ function startWebServer (done) {
 
 startExorelay( N( () => {
   startWebServer( N( () => {
-    console.log(green('HTML server is running'))
+    serviceConfig = yaml.safeLoad(fs.readFileSync(path.join(process.cwd!, 'service.yml'), 'utf8'))
+    console.log(green(serviceConfig.startup['online-text']))
   }))
 }))

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/package.json
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/package.json
@@ -11,6 +11,7 @@
     "express": "4.14.0",
     "exprestive": "1.3.0",
     "jade": "1.11.0",
+    "js-yaml": "3.7.0",
     "method-override": "2.3.6",
     "morgan": "1.7.0",
     "nitroglycerin": "1.1.2",

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/app/index.ls
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/app/index.ls
@@ -30,4 +30,5 @@ start-web-server = (done) ->
 
 start-exorelay N ->
   start-web-server N ->
-    console.log green 'HTML server is running'
+    service-config = yaml.safe-load fs.read-file-sync(path.join(process.cwd!, 'service.yml'), 'utf8')
+    console.log green service-config.startup[\online-text]

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/app/index.ls
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/app/index.ls
@@ -4,8 +4,11 @@
 require! {
   'chalk' : {cyan, dim, green, red}
   'exorelay' : ExoRelay
+  'fs'
+  'js-yaml': yaml
   'nitroglycerin' : N
   '../package.json' : {name, version}
+  'path'
   './web-server' : WebServer
 }
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/package.json
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/package.json
@@ -11,6 +11,7 @@
     "express": "4.14.0",
     "exprestive": "1.3.0",
     "jade": "1.11.0",
+    "js-yaml": "3.7.0",
     "livescript-loader": "0.1.5",
     "method-override": "2.3.6",
     "morgan": "1.7.0",

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves [Originate/exosphere-sdk#155](https://github.com/Originate/exosphere-sdk/issues/155)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
When the service comes online, the `'online-text` of `service.yml` is printed. Whereas previously the text had to be copied over, it is now read from `service.yml` itself.

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 