### PR TITLE
Change name to title in template service.ymls

### DIFF
--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -61,7 +61,7 @@ Feature: Following the tutorial
       """
     And my application contains the file "html-server/service.yml" with the content:
     """
-    name: html-server
+    title: html-server
     description: serves HTML UI for the test app
     author: test-author
 
@@ -102,7 +102,7 @@ Feature: Following the tutorial
     And waiting until the process ends
     Then my application contains the file "todo-service/service.yml" with the content:
       """
-      name: todo-service
+      title: todo-service
       description: stores the todo entries
       author: test-author
 
@@ -202,7 +202,7 @@ Feature: Following the tutorial
       """
     And the file "html-server/service.yml":
       """
-      name: html-server
+      title: html-server
       description: serves HTML UI for the test app
 
       setup: npm install --loglevel error --depth 0

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-es6/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-ls/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
@@ -1,4 +1,4 @@
-name: _____serviceName_____
+title: _____serviceName_____
 description: _____description_____
 author: _____author_____
 


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Exo commands now expect that `service.yml` contains a `title` field as opposed to a `name` field. This PR edits the template services in exosphere-shared to accommodate that.

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
