### PR TITLE
Change name to title in tutorial feature

### DIFF
--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -61,7 +61,7 @@ Feature: Following the tutorial
       """
     And my application contains the file "html-server/service.yml" with the content:
     """
-    name: html-server
+    title: html-server
     description: serves HTML UI for the test app
     author: test-author
 
@@ -102,7 +102,7 @@ Feature: Following the tutorial
     And waiting until the process ends
     Then my application contains the file "todo-service/service.yml" with the content:
       """
-      name: todo-service
+      title: todo-service
       description: stores the todo entries
       author: test-author
 
@@ -202,7 +202,7 @@ Feature: Following the tutorial
       """
     And the file "html-server/service.yml":
       """
-      name: html-server
+      title: html-server
       description: serves HTML UI for the test app
 
       setup: npm install --loglevel error --depth 0


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
With the template services now having a `title` instead of `name` field, the tutorial feature needed an update to expect that change.

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
