### PR TITLE
Append stack trace to error notification in exo-run

### DIFF
--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -53,7 +53,7 @@ class DockerRunner extends EventEmitter
 
 
   _on-container-error: ~>
-    @emit 'error', "Service '#{@name}' crashed, shutting down application"
+    @emit 'error', "Service '#{@name}' crashed, shutting down application\n\n#{(new Error).stack}"
 
 
   _run-container: ~>


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves [Originate/exosphere-sdk#33](https://github.com/Originate/exosphere-sdk/issues/33)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
A stack trace was previously not being shown with the error notification when shutting down the application. 

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 
