### PR TITLE
Ignore dotfiles in in watcher (exo-run)

### DIFF
--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -38,8 +38,9 @@ class ServiceRunner extends EventEmitter
         ..start-service!
         ..on 'online', -> done?!
         ..on 'error', (message) ~> @emit 'error', error-message: message
-
-    @watcher = watch @config.root, ignore-initial: yes, ignored: [/.*\/node_modules\/.*/, /(^|[\/\\])\../] # Ignores any sub path including dotfiles e.g. service/.cli/.swp
+        /* Ignores any sub-path including dotfiles.
+        '[\/\\]' accounts for both windows and unix systems, the '\.' matches a single '.', and the final '.' matches any character. */
+    @watcher = watch @config.root, ignore-initial: yes, ignored: [/.*\/node_modules\/.*/, /(^|[\/\\])\../] 
       ..on 'add', (added-path) ~>
         @logger.log name: 'exo-run', text: "Restarting service '#{@name}' because #{added-path} was created"
         @restart!

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -39,7 +39,7 @@ class ServiceRunner extends EventEmitter
         ..on 'online', -> done?!
         ..on 'error', (message) ~> @emit 'error', error-message: message
 
-    @watcher = watch @config.root, ignore-initial: yes, ignored: /.*\/node_modules\/.*/
+    @watcher = watch @config.root, ignore-initial: yes, ignored: [/.*\/node_modules\/.*/, /(^|[\/\\])\../]
       ..on 'add', (added-path) ~>
         @logger.log name: 'exo-run', text: "Restarting service '#{@name}' because #{added-path} was created"
         @restart!

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -39,7 +39,7 @@ class ServiceRunner extends EventEmitter
         ..on 'online', -> done?!
         ..on 'error', (message) ~> @emit 'error', error-message: message
 
-    @watcher = watch @config.root, ignore-initial: yes, ignored: [/.*\/node_modules\/.*/, /(^|[\/\\])\../]
+    @watcher = watch @config.root, ignore-initial: yes, ignored: [/.*\/node_modules\/.*/, /(^|[\/\\])\../] # Ignores any sub path including dotfiles e.g. service/.cli/.swp
       ..on 'add', (added-path) ~>
         @logger.log name: 'exo-run', text: "Restarting service '#{@name}' because #{added-path} was created"
         @restart!


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Services were being restarted, and their docker images rebuilt, if a `.swp` file was created when opening a file to work on. This change makes it so that those swapfiles are ignored by the watcher.
<!-- tag a few reviewers -->
@kevgo @martinjaime 

