### PR TITLE
Read 'service.yml' from Docker images

### DIFF
--- a/exo-run/src/app-runner.ls
+++ b/exo-run/src/app-runner.ls
@@ -47,10 +47,11 @@ class AppRunner extends EventEmitter
             {
               name: service-name
               location: service-data.location
+              image: service-data.docker-image
             }
       @runners = {}
       for service in @services
-        @runners[service.name] = new ServiceRunner {service.name, config: {root: path.join(process.cwd!, service.location), EXOCOM_PORT: @exocom-port}, @logger}
+        @runners[service.name] = new ServiceRunner {service.name, config: {root: path.join(process.cwd!, service.location), EXOCOM_PORT: @exocom-port, image: service.image}, @logger}
           ..on 'error', @shutdown
       async.parallel [runner.start for _, runner of @runners], (err) ~>
         @logger.log name: 'exo-run', text: 'all services online'

--- a/exo-run/src/app-runner.ls
+++ b/exo-run/src/app-runner.ls
@@ -47,7 +47,7 @@ class AppRunner extends EventEmitter
             {
               name: service-name
               location: service-data.location
-              image: service-data.docker-image
+              image: service-data.docker_image
             }
       @runners = {}
       for service in @services

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -18,7 +18,7 @@ require! {
 class ServiceRunner extends EventEmitter
 
   ({@name, @config, @logger}) ->
-    @service-config = yaml.safe-load fs.read-file-sync(path.join(@config.root, 'service.yml'), 'utf8')
+    @service-config = yaml.safe-load (DockerHelper.get-config @config.image)
 
 
   start: (done) ~>

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -13,6 +13,10 @@ class DockerHelper
     return "docker build -t #{image.author}/#{image.name} #{if build-flags then build-flags else ""} ."
 
 
+  @get-config = (image) ->
+    return child_process.exec-sync("docker run #{image} cat service.yml", 'utf8') |> (.to-string!)
+
+
   @get-docker-ip = (container) ->
     child_process.exec-sync("docker inspect --format '{{ .NetworkSettings.IPAddress }}' #{container}", "utf8") if @container-exists container
 


### PR DESCRIPTION
resolves [Originate/exosphere-sdk#190](https://github.com/Originate/exosphere-sdk/issues/190)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Tests will pass once the exosphere-shared related PRs are merged into this one. Instead of reading `service.yml` from a local file, this change will read it from the docker image itself. This will allow users to use services without actually having the code-base downloaded on their machine. 

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 