### PR TITLE
Fix exo-create

### DIFF
--- a/exo-create/features/create-service.feature
+++ b/exo-create/features/create-service.feature
@@ -20,6 +20,7 @@ Feature: create a reusable service
       services:
         public:
           users-service:
+            docker_image: test-author/users-service
             location: ../users-service
       """
     And my workspace contains the file "../users-service/service.yml" with content:

--- a/exo-create/src/entities/service.ls
+++ b/exo-create/src/entities/service.ls
@@ -31,7 +31,7 @@ service = ->
         file: 'application.yml'
         root: 'services.public'
         key: data.service-name
-        value: {location: "../#{data.service-name}"}
+        value: {location: "../#{data.service-name}", docker_image: "#{data.author}/#{data.service-name}"}
       yaml-cutter.insert-hash options, N ->
         console.log green "\ndone"
 


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Adds the docker_image field when creating services with `exo-create`

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 