### PR TITLE
Create dependency docker containers in exo-run

### DIFF
--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -76,7 +76,7 @@ Feature: Following the tutorial
       receives:
 
     docker:
-      link:
+      dependencies:
       publish:
     """
     When running "exo setup" in this application's directory
@@ -130,7 +130,7 @@ Feature: Following the tutorial
           - todo.updated
 
       docker:
-        link:
+        dependencies:
           - 'mongo'
       """
     When running "exo setup" in this application's directory
@@ -220,7 +220,7 @@ Feature: Following the tutorial
           - todo.listing
 
       docker:
-        link:
+        dependencies:
         publish:
           - '3000:3000'
       """

--- a/exo-run/src/app-runner.ls
+++ b/exo-run/src/app-runner.ls
@@ -26,6 +26,7 @@ class AppRunner extends EventEmitter
         @docker-config =
           author: 'originate'
           image: 'exocom'
+          app-name: @app-config.name
           start-command: 'bin/exocom'
           env:
             SERVICE_MESSAGES: service-messages
@@ -51,7 +52,7 @@ class AppRunner extends EventEmitter
             }
       @runners = {}
       for service in @services
-        @runners[service.name] = new ServiceRunner {service.name, config: {root: path.join(process.cwd!, service.location), EXOCOM_PORT: @exocom-port, image: service.image}, @logger}
+        @runners[service.name] = new ServiceRunner {service.name, config: {root: path.join(process.cwd!, service.location), EXOCOM_PORT: @exocom-port, image: service.image, app-name: @app-config.name}, @logger}
           ..on 'error', @shutdown
       async.parallel [runner.start for _, runner of @runners], (err) ~>
         @logger.log name: 'exo-run', text: 'all services online'

--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -30,6 +30,7 @@ class DockerRunner extends EventEmitter
       | otherwise  =>
         wait-until (~> DockerHelper.get-docker-ip 'exocom'), 10, ~>
           @docker-config.env.EXOCOM_HOST = DockerHelper.get-docker-ip 'exocom'
+          @_check-dependency-containers!
           @_run-container!
 
 
@@ -45,8 +46,6 @@ class DockerRunner extends EventEmitter
       command += " -e #{name}=#{val}"
     for name, port of @docker-config.publish
       command += " --publish #{port}"
-    for link, container of  @docker-config.link
-      command += " --link #{container}"
     command += " 
       #{@docker-config.author}/#{@docker-config.image} 
       #{@docker-config.start-command}"
@@ -65,6 +64,13 @@ class DockerRunner extends EventEmitter
       ..wait @docker-config.start-text, ~>
         @logger.log name: 'exo-run', text: "'#{@name}' is running"
         @emit 'online'
+
+
+  _check-dependency-containers: ~>
+    for link, container of @docker-config.link
+      app-container = "#{@docker-config.app-name}-#{container}"
+      DockerHelper.ensure-container-is-running app-container, container
+      @docker-config.env["#{container.to-upper-case!}"] = DockerHelper.get-docker-ip app-container
 
 
 

--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -67,7 +67,7 @@ class DockerRunner extends EventEmitter
 
 
   _check-dependency-containers: ~>
-    for link, container of @docker-config.link
+    for dependency, container of @docker-config.dependencies
       app-container = "#{@docker-config.app-name}-#{container}"
       DockerHelper.ensure-container-is-running app-container, container
       @docker-config.env["#{container.to-upper-case!}"] = DockerHelper.get-docker-ip app-container

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -25,6 +25,7 @@ class ServiceRunner extends EventEmitter
     @docker-config =
       author: @service-config.author
       image: dashify @service-config.title
+      app-name: dashify @config.app-name
       start-command: @service-config.startup.command
       start-text: @service-config.startup['online-text']
       cwd: @config.root

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -32,8 +32,8 @@ class ServiceRunner extends EventEmitter
       env:
         EXOCOM_PORT: @config.EXOCOM_PORT
         SERVICE_NAME: @name
-      publish: @service-config.docker.publish if @service-config.docker
-      dependencies: @service-config.docker.dependencies if @service-config.docker
+      publish: @service-config.docker?.publish
+      dependencies: @service-config.docker?.dependencies
 
     @docker-runner = new DockerRunner {@name, @docker-config, @logger}
         ..start-service!

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -33,7 +33,7 @@ class ServiceRunner extends EventEmitter
         EXOCOM_PORT: @config.EXOCOM_PORT
         SERVICE_NAME: @name
       publish: @service-config.docker.publish if @service-config.docker
-      link: @service-config.docker.link if @service-config.docker
+      dependencies: @service-config.docker.dependencies if @service-config.docker
 
     @docker-runner = new DockerRunner {@name, @docker-config, @logger}
         ..start-service!

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -9,10 +9,10 @@ class DockerHelper
     child_process.exec-sync('docker ps -a --format {{.Names}}', 'utf8') |> (.includes container)
 
 
-  @ensure-container-is-running = (container, image) ->
-    return if child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}' , 'utf8') |> (.includes "#{container}/Up")
-    @remove-container that if @container-exists container
-    @run-image container, image
+  @ensure-container-is-running = (container-name, image) ->
+    return if child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}' , 'utf8') |> (.includes "#{container-name}/Up")
+    return child_process.exec-sync("docker start #{container-name}") if @container-exists container-name
+    @run-image container-name, image
 
 
   @get-build-command = (image, build-flags) ->
@@ -20,7 +20,7 @@ class DockerHelper
 
 
   @get-config = (image) ->
-    return child_process.exec-sync("docker run #{image} cat service.yml", 'utf8') |> (.to-string!)
+    return child_process.exec-sync("docker run --rm=true #{image} cat service.yml", 'utf8') |> (.to-string!)
 
 
   @get-docker-ip = (container) ->

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -9,6 +9,12 @@ class DockerHelper
     child_process.exec-sync('docker ps -a --format {{.Names}}', 'utf8') |> (.includes container)
 
 
+  @ensure-container-is-running = (container, image) ->
+    return if child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}' , 'utf8') |> (.includes "#{container}/Up")
+    @remove-container that if @container-exists container
+    @run-image container, image
+
+
   @get-build-command = (image, build-flags) ->
     return "docker build -t #{image.author}/#{image.name} #{if build-flags then build-flags else ""} ."
 
@@ -32,6 +38,9 @@ class DockerHelper
   @remove-container = (container) ->
     child_process.exec-sync "docker rm -f #{container}" if @container-exists container
 
+
+  @run-image = (container, image) ->
+    child_process.exec-sync "docker run -d --name=#{container} #{image}"
 
   @image-exists = (image) ->
     child_process.exec-sync("docker images #{image.author}/#{image.name}#{if image.version then ":#{image.version}" else ""}", "utf-8") |> (.includes "#{image.author}/#{image.name}")

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
@@ -25,5 +25,5 @@ messages:
     - _____modelName_____.updated
 
 docker:
-  link:
+  dependencies:
     - 'mongo'

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/src/server.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/src/server.js
@@ -10,7 +10,7 @@ module.exports = {
 
   beforeAll: (done) => {
     const mongoDbName = `exosphere-_____serviceName_____-${env}`
-    const mongoAddress = (env === 'test') ? 'localhost' : 'mongo'
+    const mongoAddress = (env === 'test') ? 'localhost' : process.env.MONGO
     MongoClient.connect(`mongodb://${mongoAddress}:27017/${mongoDbName}`, N( (mongoDb) => {
       collection = mongoDb.collection('_____modelName_____s')
       console.log(`MongoDB '${mongoDbName}' connected`)

--- a/exosphere-shared/templates/add-service/exoservice-es6/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6/service.yml
@@ -15,4 +15,4 @@ messages:
     - pong
 
 docker:
-  link:
+  dependencies:

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
@@ -25,5 +25,5 @@ messages:
     - _____modelName_____.updated
 
 docker:
-  link:
+  dependencies:
     - 'mongo'

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/src/server.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/src/server.ls
@@ -11,7 +11,7 @@ module.exports =
 
   before-all: (done) ->
     mongo-db-name = "exosphere-_____serviceName_____-#{env}"
-    mongo-address = if env is \test then \localhost else \mongo
+    mongo-address = if env is \test then \localhost else process.env.MONGO
     MongoClient.connect "mongodb://#{mongo-address}:27017/#{mongo-db-name}", N (mongo-db) ->
       collection := mongo-db.collection '_____modelName_____s'
       console.log "MongoDB '#{mongo-db-name}' connected"

--- a/exosphere-shared/templates/add-service/exoservice-ls/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls/service.yml
@@ -15,4 +15,4 @@ messages:
     - pong
 
 docker:
-  link:
+  dependencies:

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
@@ -12,5 +12,5 @@ messages:
   receives:
 
 docker:
-  link:
+  dependencies:
   publish:

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
@@ -12,6 +12,6 @@ messages:
   receives:
 
 docker:
-  link:
+  dependencies:
   publish:
     - '3000:3000'


### PR DESCRIPTION
resolves [Originate/exosphere-sdk#183](https://github.com/Originate/exosphere-sdk/issues/183)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Reads the link field of each service's `service.yml` file and makes sure that docker containers are running for each of the specified dependencies. The ip address of the container is then passed to the service itself so that it can connect to the running docker container.

The naming convention for these dependency containers is a "dashified" `app-name`, appended with the name of the dependency, e.g. `space-tweet-mongo`.

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 