### PR TITLE
Fix bug in DockerHelper

### DIFF
--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -40,6 +40,9 @@ class DockerHelper
 
 
   @remove-container = (container) ->
+    console.log container, \TO_BE_REMOVED
+    console.log (child_process.exec-sync('docker ps -a', 'utf8') |> (.to-string!))
+    console.log \^ALL_CONTAINERS^
     child_process.exec-sync "docker rm -f #{container}" if @container-exists container
 
 

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -6,11 +6,11 @@ require! {
 class DockerHelper
 
   @container-exists = (container) ->
-    child_process.exec-sync('docker ps -a --format {{.Names}}', 'utf8') |> (.includes container)
+    child_process.exec-sync('docker ps -a --format {{.Names}}') |> (.to-string!) |> (.split '\n') |> (.includes container)
 
 
   @container-is-running = (container-name) ->
-    child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}' , 'utf8') |> (.includes "#{container-name}/Up")
+    child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}') |> (.to-string!) |> (.split '\n') |> (.includes "#{container-name}/Up")
 
 
   @ensure-container-is-running = (container-name, image) ->
@@ -40,9 +40,6 @@ class DockerHelper
 
 
   @remove-container = (container) ->
-    console.log container, \TO_BE_REMOVED
-    console.log (child_process.exec-sync('docker ps -a', 'utf8') |> (.to-string!))
-    console.log \^ALL_CONTAINERS^
     child_process.exec-sync "docker rm -f #{container}" if @container-exists container
 
 


### PR DESCRIPTION
resolves [Originate/exosphere-sdk#203](https://github.com/Originate/exosphere-sdk/issues/203)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
There was a bug in the `container-exists` method of DockerHelper that was incorrectly returning true sometimes. 

The issue arose when a name of a container was a subset of another. E.g. Docker container `users-service` exists and we are checking for `users`. We would receive true, and then potentially attempt to remove the `users` container, resulting in an error as it doesn't exist. This has been fixed now.

<!-- tag a few reviewers -->
@kevgo @martinjaime 