### PR TITLE
Use mongo Docker image in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 
 services:
   - docker
-  - mongodb
 
 node_js:
   - "6"

--- a/cli/features/steps/steps.ls
+++ b/cli/features/steps/steps.ls
@@ -1,6 +1,7 @@
 require! {
   'async'
   'chai' : {expect}
+  'child_process'
   'dim-console'
   'fs-extra' : fs
   '../../../exosphere-shared' : {call-args, DockerHelper}
@@ -106,6 +107,14 @@ module.exports = ->
 
   @When /^waiting until the process ends$/, timeout: 300_000, (done) ->
     @process.on 'ended', done
+
+
+  @When /^setting up a temporary mongo docker container$/ ->
+    child_process.exec-sync 'docker run -d --name=test-mongo -p 27017:27017 mongo'
+
+
+  @When /^removing the temporary mongo docker container$/ ->
+    DockerHelper.remove-container \test-mongo
 
 
   @Then /^I stop all running processes$/, (done) ->

--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -134,7 +134,9 @@ Feature: Following the tutorial
           - 'mongo'
       """
     When running "exo setup" in this application's directory
+    And setting up a temporary mongo docker container
     And running "exo test" in this application's directory
+    And removing the temporary mongo docker container
     Then it prints "todo-service works" in the terminal
     And it prints "html-server has no tests, skipping" in the terminal
     And it prints "All tests passed" in the terminal


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Previously we were requiring `mongodb` as a service to be running in Travis, for part of the tutorial feature. Now, when running the feature tests for the service created in `tutorial.feature`, a mongo container is started up beforehand with port `27017` exposed as to be accessible through `localhost`. It is then removed afterwards as it is no longer needed from that point. This can be changed to a more elegant solution in the future as we create the fully fledged `tutorial runner`.

<!-- tag a few reviewers -->
@kevgo @martinjaime 