### PR TITLE
Change link to dependency

### DIFF
--- a/exo-add/features/exoservice-es6-mongodb.feature
+++ b/exo-add/features/exoservice-es6-mongodb.feature
@@ -54,7 +54,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
           - user.updated
 
       docker:
-        link:
+        dependencies:
           - 'mongo'
       """
     And my application contains the file "user-service/src/server.js"

--- a/exo-add/features/exoservice-es6.feature
+++ b/exo-add/features/exoservice-es6.feature
@@ -43,7 +43,7 @@ Feature: scaffolding an ExoService written in ES6
           - pong
 
       docker:
-        link:
+        dependencies:
       """
     And my application contains the file "users/src/server.js" with the content:
       """

--- a/exo-add/features/exoservice-ls-mongodb.feature
+++ b/exo-add/features/exoservice-ls-mongodb.feature
@@ -53,7 +53,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
           - user.updated
 
       docker:
-        link:
+        dependencies:
           - 'mongo'
       """
     And my application contains the file "user-service/src/server.ls"

--- a/exo-add/features/exoservice-ls.feature
+++ b/exo-add/features/exoservice-ls.feature
@@ -43,7 +43,7 @@ Feature: scaffolding an ExoService written in LiveScript
           - pong
 
       docker:
-        link:
+        dependencies:
       """
     And my application contains the file "users/src/server.ls" with the content:
       """

--- a/exo-add/features/htmlserver-express-es6.feature
+++ b/exo-add/features/htmlserver-express-es6.feature
@@ -39,7 +39,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
         receives:
 
       docker:
-        link:
+        dependencies:
         publish:
       """
     And my application contains the file "html-server/README.md" containing the text:
@@ -85,7 +85,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
         receives:
 
       docker:
-        link:
+        dependencies:
         publish:
       """
     And my application contains the file "html-server/README.md" containing the text:

--- a/exo-add/features/htmlserver-express-livescript.feature
+++ b/exo-add/features/htmlserver-express-livescript.feature
@@ -39,7 +39,7 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
         receives:
 
       docker:
-        link:
+        dependencies:
         publish:
           - '3000:3000'
       """

--- a/exo-create/features/create-service.feature
+++ b/exo-create/features/create-service.feature
@@ -52,6 +52,6 @@ Feature: create a reusable service
           - user.updated
 
       docker:
-        link:
+        dependencies:
           - 'mongo'
       """

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -112,7 +112,7 @@ class AwsTerraformFileBuilder
       cpu: service-config.docker.cpu
       memory: service-config.docker.memory
       command: service-config.command
-      links: service-config.docker.links
+      dependencies: service-config.docker.dependencies
       port-mappings: @_build-port-mappings service-config
       environment:
         * name: 'EXOCOM_HOST'


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Change the field `link` to `dependencies` in `exo-add` and `exo-create` feature tests, as well as in `exo-deploy`. 

<!-- tag a few reviewers -->
@kevgo @hugobho @martinjaime 