### PR TITLE
Create and destroy dependencies in exo-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 
 services:
   - docker
-  - mongodb
 
 node_js:
   - "6"

--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -75,8 +75,9 @@ Feature: Following the tutorial
       sends:
       receives:
 
+    dependencies:
+
     docker:
-      dependencies:
       publish:
     """
     When running "exo setup" in this application's directory
@@ -129,9 +130,8 @@ Feature: Following the tutorial
           - todo.details
           - todo.updated
 
-      docker:
-        dependencies:
-          - 'mongo'
+      dependencies:
+        - 'mongo'
       """
     When running "exo setup" in this application's directory
     And running "exo test" in this application's directory
@@ -220,8 +220,9 @@ Feature: Following the tutorial
           - todo.created
           - todo.listing
 
+      dependencies:
+
       docker:
-        dependencies:
         publish:
           - '3000:3000'
       """

--- a/exo-add/features/exoservice-es6-mongodb.feature
+++ b/exo-add/features/exoservice-es6-mongodb.feature
@@ -53,9 +53,8 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
           - user.details
           - user.updated
 
-      docker:
-        link:
-          - 'mongo'
+      dependencies:
+        - 'mongo'
       """
     And my application contains the file "user-service/src/server.js"
     And my application contains the file "user-service/README.md" containing the text:

--- a/exo-add/features/exoservice-es6.feature
+++ b/exo-add/features/exoservice-es6.feature
@@ -42,8 +42,7 @@ Feature: scaffolding an ExoService written in ES6
         sends:
           - pong
 
-      docker:
-        link:
+      dependencies:
       """
     And my application contains the file "users/src/server.js" with the content:
       """

--- a/exo-add/features/exoservice-ls-mongodb.feature
+++ b/exo-add/features/exoservice-ls-mongodb.feature
@@ -52,9 +52,8 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
           - user.listing
           - user.updated
 
-      docker:
-        link:
-          - 'mongo'
+      dependencies:
+        - 'mongo'
       """
     And my application contains the file "user-service/src/server.ls"
     And my application contains the file "user-service/README.md" containing the text:

--- a/exo-add/features/exoservice-ls.feature
+++ b/exo-add/features/exoservice-ls.feature
@@ -42,8 +42,7 @@ Feature: scaffolding an ExoService written in LiveScript
         sends:
           - pong
 
-      docker:
-        link:
+      dependencies:
       """
     And my application contains the file "users/src/server.ls" with the content:
       """

--- a/exo-add/features/htmlserver-express-es6.feature
+++ b/exo-add/features/htmlserver-express-es6.feature
@@ -38,8 +38,9 @@ Feature: scaffolding an ExpressJS html server written in ES6
         sends:
         receives:
 
+      dependencies:
+
       docker:
-        link:
         publish:
       """
     And my application contains the file "html-server/README.md" containing the text:
@@ -84,8 +85,9 @@ Feature: scaffolding an ExpressJS html server written in ES6
         sends:
         receives:
 
+      dependencies:
+
       docker:
-        link:
         publish:
       """
     And my application contains the file "html-server/README.md" containing the text:

--- a/exo-add/features/htmlserver-express-livescript.feature
+++ b/exo-add/features/htmlserver-express-livescript.feature
@@ -38,8 +38,9 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
         sends:
         receives:
 
+      dependencies:
+
       docker:
-        link:
         publish:
           - '3000:3000'
       """

--- a/exo-create/features/create-service.feature
+++ b/exo-create/features/create-service.feature
@@ -51,7 +51,6 @@ Feature: create a reusable service
           - user.details
           - user.updated
 
-      docker:
-        link:
-          - 'mongo'
+      dependencies:
+        - 'mongo'
       """

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -112,7 +112,7 @@ class AwsTerraformFileBuilder
       cpu: service-config.docker.cpu
       memory: service-config.docker.memory
       command: service-config.command
-      links: service-config.docker.links
+      dependencies: service-config.dependencies
       port-mappings: @_build-port-mappings service-config
       environment:
         * name: 'EXOCOM_HOST'

--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -67,10 +67,10 @@ class DockerRunner extends EventEmitter
 
 
   _check-dependency-containers: ~>
-    for dependency, container of @docker-config.dependencies
-      app-container = "#{@docker-config.app-name}-#{container}"
-      DockerHelper.ensure-container-is-running app-container, container
-      @docker-config.env["#{container.to-upper-case!}"] = DockerHelper.get-docker-ip app-container
+    for dependency in @docker-config.dependencies
+      app-dependency = "#{@docker-config.app-name}-#{dependency}"
+      DockerHelper.ensure-container-is-running app-dependency, dependency
+      @docker-config.env["#{dependency.to-upper-case!}"] = DockerHelper.get-docker-ip app-dependency
 
 
 

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -33,7 +33,7 @@ class ServiceRunner extends EventEmitter
         EXOCOM_PORT: @config.EXOCOM_PORT
         SERVICE_NAME: @name
       publish: @service-config.docker?.publish
-      dependencies: @service-config.docker?.dependencies
+      dependencies: @service-config.dependencies ? []
 
     @docker-runner = new DockerRunner {@name, @docker-config, @logger}
         ..start-service!

--- a/exo-test/src/app-tester.ls
+++ b/exo-test/src/app-tester.ls
@@ -26,7 +26,6 @@ class AppTester extends EventEmitter
       | err                             =>  @emit 'all-tests-failed'
       | @_contains-non-zero exit-codes  =>  @emit 'all-tests-failed'
       | otherwise                       =>  @emit 'all-tests-passed'
-      async.series [tester.remove-dependencies for tester in testers]
 
 
   _contains-non-zero: (exit-codes) ->

--- a/exo-test/src/app-tester.ls
+++ b/exo-test/src/app-tester.ls
@@ -26,6 +26,7 @@ class AppTester extends EventEmitter
       | err                             =>  @emit 'all-tests-failed'
       | @_contains-non-zero exit-codes  =>  @emit 'all-tests-failed'
       | otherwise                       =>  @emit 'all-tests-passed'
+      async.series [tester.remove-dependencies for tester in testers]
 
 
   _contains-non-zero: (exit-codes) ->

--- a/exo-test/src/cli.ls
+++ b/exo-test/src/cli.ls
@@ -36,7 +36,8 @@ function test-service
     ..on 'service-tests-passed', (name) -> logger.log name: 'exo-test', text: "#{name} works"
     ..on 'service-tests-failed', (name) -> logger.log name: 'exo-test', text: "#{name} is broken"
     ..on 'service-tests-skipped', (name) -> logger.log name: 'exo-test', text: "#{name} has no tests, skipping"
-    ..start!
+    ..start ~>
+      ..remove-dependencies!
 
 function test-app
   app-config = yaml.safe-load fs.read-file-sync('application.yml', 'utf8')

--- a/exo-test/src/service-tester.ls
+++ b/exo-test/src/service-tester.ls
@@ -30,17 +30,17 @@ class ServiceTester extends EventEmitter
           @emit 'service-tests-failed', @name
         else
           @emit 'service-tests-passed', @name
+        @remove-dependencies!
         done?(null, exit-code)
 
 
   remove-dependencies: ~>
-    return unless @service-config.docker
-    for dep in @service-config.docker.dependencies
+    for dep in @service-config.dependencies or []
       DockerHelper.remove-container "test-#{dep}"
 
+
   _start-dependencies: ~>
-    return unless @service-config.docker
-    for dep in @service-config.docker.dependencies
+    for dep in @service-config.dependencies or []
       DockerHelper.ensure-container-is-running "test-#{dep}", dep
 
 

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -44,7 +44,10 @@ class DockerHelper
 
 
   @run-image = (container, image) ->
-    child_process.exec-sync "docker run -d --name=#{container} #{image}"
+    if image is \mongo
+      child_process.exec-sync "docker run -d --name=#{container} -p 27017:27017 #{image}"
+    else
+      child_process.exec-sync "docker run -d --name=#{container} #{image}"
 
 
   @start-container = (container-name) ->

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
@@ -24,6 +24,5 @@ messages:
     - _____modelName_____.details
     - _____modelName_____.updated
 
-docker:
-  dependencies:
-    - 'mongo'
+dependencies:
+  - 'mongo'

--- a/exosphere-shared/templates/add-service/exoservice-es6/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6/service.yml
@@ -14,5 +14,4 @@ messages:
   sends:
     - pong
 
-docker:
-  dependencies:
+dependencies:

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
@@ -24,6 +24,5 @@ messages:
     - _____modelName_____.listing
     - _____modelName_____.updated
 
-docker:
-  dependencies:
-    - 'mongo'
+dependencies:
+  - 'mongo'

--- a/exosphere-shared/templates/add-service/exoservice-ls/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls/service.yml
@@ -14,5 +14,4 @@ messages:
   sends:
     - pong
 
-docker:
-  dependencies:
+dependencies:

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
@@ -11,6 +11,7 @@ messages:
   sends:
   receives:
 
+dependencies:
+
 docker:
-  dependencies:
   publish:

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
@@ -11,7 +11,8 @@ messages:
   sends:
   receives:
 
+dependencies:
+
 docker:
-  dependencies:
   publish:
     - '3000:3000'


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #81

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
`exo-test` now reads the dependencies section of `service.yml` and creates docker containers for the dependencies listed. The names of these containers are prepended with `test` as to not interfere with other containers that may be running. 

Another PR will be coming soon to address moving the `dependencies` section out of the `docker` section in `service.yml`

<!-- tag a few reviewers -->
@kevgo @martinjaime @hugobho 