### PR TITLE
Wait for dependencies to start

### DIFF
--- a/exo-test/package.json
+++ b/exo-test/package.json
@@ -7,7 +7,8 @@
     "chalk": "1.1.3",
     "js-yaml": "3.7.0",
     "observable-process": "3.2.0",
-    "prelude-ls": "1.1.2"
+    "prelude-ls": "1.1.2",
+    "wait": "0.1.0"
   },
   "description": "The 'exo-test' command",
   "devDependencies": {

--- a/exo-test/src/app-tester.ls
+++ b/exo-test/src/app-tester.ls
@@ -19,6 +19,7 @@ class AppTester extends EventEmitter
         service-dir = path.join process.cwd!, service-data.location
         testers.push (new ServiceTester service-name, root: service-dir
           ..on 'output', (data) ~> @emit 'output', data
+          ..on 'error', (err) ~> @emit 'error', err
           ..on 'service-tests-passed', (name) ~> @emit 'service-tests-passed', name
           ..on 'service-tests-failed', (name) ~> @emit 'service-tests-failed', name
           ..on 'service-tests-skipped', (name) ~> @emit 'service-tests-skipped', name)

--- a/exo-test/src/cli.ls
+++ b/exo-test/src/cli.ls
@@ -33,6 +33,7 @@ function test-service
     ..log name: 'exo-test', text: "Testing service '#{service-name}'"
   new ServiceTester service-name, root: process.cwd!
     ..on 'output', (data) ~> logger.log data
+    ..on 'error', (err) ~> logger.log "Error: #{err}"
     ..on 'service-tests-passed', (name) -> logger.log name: 'exo-test', text: "#{name} works"
     ..on 'service-tests-failed', (name) -> logger.log name: 'exo-test', text: "#{name} is broken"
     ..on 'service-tests-skipped', (name) -> logger.log name: 'exo-test', text: "#{name} has no tests, skipping"
@@ -45,6 +46,7 @@ function test-app
     ..log name: 'exo-test', text: "Testing application '#{app-config.name}'"
   app-tester = new AppTester app-config
     ..on 'output', (data) -> logger.log data
+    ..on 'error', (err) ~> logger.log "Error: #{err}"
     ..on 'all-tests-passed', -> logger.log name: 'exo-test', text: 'All tests passed'
     ..on 'all-tests-failed', -> logger.log name: 'exo-test', text: 'Tests failed'; process.exit 1
     ..on 'service-tests-passed', (name) -> logger.log name: 'exo-test', text: "#{name} works"

--- a/exo-test/src/service-tester.ls
+++ b/exo-test/src/service-tester.ls
@@ -20,8 +20,7 @@ class ServiceTester extends EventEmitter
       @emit 'service-tests-skipped', @name
       return done?!
 
-    @_start-dependencies!
-    wait 500, ~>
+    @_start-dependencies ~>
       new ObservableProcess(call-args(@_create-command @service-config.tests)
                             cwd: @config.root,
                             env: @config
@@ -41,9 +40,10 @@ class ServiceTester extends EventEmitter
       DockerHelper.remove-container "test-#{dep}"
 
 
-  _start-dependencies: ~>
+  _start-dependencies: (done) ~>
     for dep in @service-config.dependencies or []
       DockerHelper.ensure-container-is-running "test-#{dep}", dep
+    wait 500, done
 
 
   _create-command: (command) ->

--- a/exo-test/src/service-tester.ls
+++ b/exo-test/src/service-tester.ls
@@ -5,6 +5,7 @@ require! {
   'js-yaml' : yaml
   'observable-process' : ObservableProcess
   'path'
+  'wait' : {wait}
 }
 
 
@@ -20,18 +21,19 @@ class ServiceTester extends EventEmitter
       return done?!
 
     @_start-dependencies!
-    new ObservableProcess(call-args(@_create-command @service-config.tests)
-                          cwd: @config.root,
-                          env: @config
-                          stdout: {@write}
-                          stderr: {@write})
-      ..on 'ended', (exit-code) ~>
-        if exit-code > 0
-          @emit 'service-tests-failed', @name
-        else
-          @emit 'service-tests-passed', @name
-        @remove-dependencies!
-        done?(null, exit-code)
+    wait 500, ~>
+      new ObservableProcess(call-args(@_create-command @service-config.tests)
+                            cwd: @config.root,
+                            env: @config
+                            stdout: {@write}
+                            stderr: {@write})
+        ..on 'ended', (exit-code) ~>
+          if exit-code > 0
+            @emit 'service-tests-failed', @name
+          else
+            @emit 'service-tests-passed', @name
+          @remove-dependencies!
+          done?(null, exit-code)
 
 
   remove-dependencies: ~>

--- a/exo-test/src/service-tester.ls
+++ b/exo-test/src/service-tester.ls
@@ -20,7 +20,8 @@ class ServiceTester extends EventEmitter
       @emit 'service-tests-skipped', @name
       return done?!
 
-    @_start-dependencies ~>
+    @_start-dependencies (err) ~>
+      | err => @emit 'error', err ; return
       new ObservableProcess(call-args(@_create-command @service-config.tests)
                             cwd: @config.root,
                             env: @config

--- a/exo-test/yarn.lock
+++ b/exo-test/yarn.lock
@@ -1819,6 +1819,10 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
+wait@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/wait/-/wait-0.1.0.tgz#8c3e1c7252d531a13fe444fb6be09511b0ce7168"
+
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->


<!-- a short description of the change in addition to what is already mentioned in the issue above -->
`exo-tests` starts a Mongo container if a service lists 'mongo' as a dependency. The Docker containers were being started but Mongo itself was taking longer to boot up within the container, so tests that use Mongo would fail with this error: `MongoError: connection 0 to localhost:27017 closed`

<!-- tag a few reviewers -->
@kevgo @trushton 