### PR TITLE
Update exo-test to use new service.yml format

### DIFF
--- a/exo-test/src/service-tester.ls
+++ b/exo-test/src/service-tester.ls
@@ -36,12 +36,12 @@ class ServiceTester extends EventEmitter
 
 
   remove-dependencies: ~>
-    for dep in @service-config.dependencies or []
+    for dep of @service-config.dependencies
       DockerHelper.remove-container "test-#{dep}"
 
 
   _start-dependencies: (done) ~>
-    for dep in @service-config.dependencies or []
+    for dep of @service-config.dependencies
       DockerHelper.ensure-container-is-running "test-#{dep}", dep
     wait 500, done
 


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->


<!-- a short description of the change in addition to what is already mentioned in the issue above --> 
using this format:
```
dependencies:
  mongo:
    prod: 'ds143588.mlab.com:43588'
```

<!-- tag a few reviewers -->
@kevgo @trushton 