### PR TITLE
Use third-party hosted database

### DIFF
--- a/exo-deploy/src/docker/docker.ls
+++ b/exo-deploy/src/docker/docker.ls
@@ -42,6 +42,8 @@ class Docker
     flags = "-v #{process.cwd!}:/var/app:ro " +
             "--env AWS_ACCESS_KEY_ID=#{process.env.AWS_ACCESS_KEY_ID} " +
             "--env AWS_SECRET_ACCESS_KEY=#{process.env.AWS_SECRET_ACCESS_KEY} "
+    if process.env.MONGODB_USER then flags += "--env MONGODB_USER=#{process.env.MONGODB_USER} "
+    if process.env.MONGODB_PW   then flags += "--env MONGODB_PW=#{process.env.MONGODB_PW}"
     new ObservableProcess("docker run #{flags} originate/exo-deploy:#{@version} #{command-flag}",
                           stdout: {@write}
                           stderr: {@write})

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -79,8 +79,8 @@ class AwsTerraformFileBuilder
       @_build-service-container-definition service-name, (@_get-image-name service-data), service-config
       data =
         name: service-name
-        public-port: service-config.docker['public-port']
-        public-url: service-config['deployment-url']
+        public-port: service-config.production['aws-task-definition']['public-port']
+        public-url: service-config.production.url
       @_append-to-main-script {data, template-name: "#{type}-service.tf"}
 
 
@@ -111,18 +111,11 @@ class AwsTerraformFileBuilder
     container-definition = [
       name: "exosphere-#{service-name}-service"
       image: image-name
-      cpu: service-config.docker.cpu
-      memory: service-config.docker.memory
-      command: service-config.command
-      dependencies: service-config.dependencies
+      cpu: service-config.production['aws-task-definition'].cpu
+      memory: service-config.production['aws-task-definition'].memory
+      command: service-config.startup.command |> (.split ' ')
       port-mappings: @_build-port-mappings service-config
-      environment:
-        * name: 'EXOCOM_HOST'
-          value: @exocom-dns
-        * name: 'EXOCOM_PORT'
-          value: "#{@exocom-port}"
-        * name: 'SERVICE_NAME'
-          value: service-name
+      environment: @_build-service-environment-variables service-name, service-config
       ]
     target-path = path.join @terraform-path, "#{service-name}-container-definition.json"
     fs.write-file-sync target-path, JSON.stringify(container-definition, null, 2)
@@ -136,12 +129,30 @@ class AwsTerraformFileBuilder
       container-port: @exocom-port
       protocol: 'tcp'
     ]
-    if service-config.docker['public-port']
+    if service-config.production['aws-task-definition']['public-port']
       port-mappings.push do
         host-port: 80
-        container-port: service-config.docker['public-port']
+        container-port: service-config.production['aws-task-definition']['public-port']
         protocol: 'tcp'
     port-mappings
+
+
+  _build-service-environment-variables: (service-name, service-config) ->
+    environment =
+      * name: 'EXOCOM_HOST'
+        value: @exocom-dns
+      * name: 'EXOCOM_PORT'
+        value: "#{@exocom-port}"
+      * name: 'SERVICE_NAME'
+        value: service-name
+    for dependency of service-config.dependencies
+      switch dependency
+        | 'mongo' =>
+          process.env.MONGODB_USER ? throw new Error "MONGODB_USER not provided"
+          process.env.MONGODB_PW ? throw new Error "MONGODB_PW not provided"
+          environment ++= {name: 'MONGODB_USER', value: process.env.MONGODB_USER}
+          environment ++= {name: 'MONGODB_PW', value: process.env.MONGODB_PW}
+    environment
 
 
   _build-exocom-container-definition: ->

--- a/exo-deploy/src/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/terraform/aws-terraform-file-builder.ls
@@ -79,7 +79,7 @@ class AwsTerraformFileBuilder
       @_build-service-container-definition service-name, (@_get-image-name service-data), service-config
       data =
         name: service-name
-        public-port: service-config.production['aws-task-definition']['public-port']
+        public-port: service-config.production.aws['public-port']
         public-url: service-config.production.url
       @_append-to-main-script {data, template-name: "#{type}-service.tf"}
 
@@ -111,8 +111,8 @@ class AwsTerraformFileBuilder
     container-definition = [
       name: "exosphere-#{service-name}-service"
       image: image-name
-      cpu: service-config.production['aws-task-definition'].cpu
-      memory: service-config.production['aws-task-definition'].memory
+      cpu: service-config.production.aws.cpu
+      memory: service-config.production.aws.memory
       command: service-config.startup.command |> (.split ' ')
       port-mappings: @_build-port-mappings service-config
       environment: @_build-service-environment-variables service-name, service-config
@@ -129,10 +129,10 @@ class AwsTerraformFileBuilder
       container-port: @exocom-port
       protocol: 'tcp'
     ]
-    if service-config.production['aws-task-definition']['public-port']
+    if service-config.production.aws['public-port']
       port-mappings.push do
         host-port: 80
-        container-port: service-config.production['aws-task-definition']['public-port']
+        container-port: service-config.production.aws['public-port']
         protocol: 'tcp'
     port-mappings
 


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Use Mlabs hosted database in production. This PR goes along with the changes made to `service.yml` here: Originate/space-tweet/pull/13

<!-- tag a few reviewers -->
@kevgo @trushton 