### PR TITLE
Set node env

### DIFF
--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -41,7 +41,7 @@ class DockerRunner extends EventEmitter
   _create-run-command: ->
     command = "
       docker run 
-        --name=#{@docker-config.env.SERVICE_NAME} "
+        --name=#{@docker-config.env.SERVICE_NAME} -e NODE_ENV=dev"
     for name, val of @docker-config.env
       command += " -e #{name}=#{val}"
     for name, port of @docker-config.publish


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
The base image for the node services (`nodesource/node`) sets `NODE_ENV=prod` by default. In `exo-run` we need `NODE_ENV=dev`. 

However, this change isn't language agnostic. We need some way to determine what language a service is written in and set the necessary environment variables. Perhaps we could do something like this in `service.yml`:
```
development:
  docker:
    env:
      - 'NODE_ENV=dev'
    publish:
      - '3000:3000'
```
<!-- tag a few reviewers -->
@kevgo @trushton 