### PR TITLE
Add 'bin/setup' to dependency-lint

### DIFF
--- a/exo-add/dependency-lint.yml
+++ b/exo-add/dependency-lint.yml
@@ -9,6 +9,7 @@ executedModules:
     dev:
       - bin/features
       - bin/features.cmd
+      - bin/setup
       - bin/spec
       - bin/spec_ci
       - bin/spec.cmd

--- a/exo-create/dependency-lint.yml
+++ b/exo-create/dependency-lint.yml
@@ -9,6 +9,7 @@ executedModules:
     dev:
       - bin/features
       - bin/features.cmd
+      - bin/setup
       - bin/spec
       - bin/spec_ci
       - bin/spec.cmd

--- a/exo-run/dependency-lint.yml
+++ b/exo-run/dependency-lint.yml
@@ -9,6 +9,7 @@ executedModules:
     dev:
       - bin/features
       - bin/features.cmd
+      - bin/setup
       - bin/spec
       - bin/spec_ci
       - bin/spec.cmd

--- a/exo-setup/dependency-lint.yml
+++ b/exo-setup/dependency-lint.yml
@@ -9,6 +9,7 @@ executedModules:
     dev:
       - bin/features
       - bin/features.cmd
+      - bin/setup
       - bin/spec
       - bin/spec_ci
       - bin/spec.cmd

--- a/exo-test/dependency-lint.yml
+++ b/exo-test/dependency-lint.yml
@@ -9,6 +9,7 @@ executedModules:
     dev:
       - bin/features
       - bin/features.cmd
+      - bin/setup
       - bin/spec
       - bin/spec_ci
       - bin/spec.cmd


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->Now that `bin/setup` runs `o-tools-livescript/build`, it needs to be added to the dependency-lint

<!-- tag a few reviewers -->
@kevgo @hugobho 