### PR TITLE
Remove command used to build webpack

### DIFF
--- a/cli/bin/setup
+++ b/cli/bin/setup
@@ -18,4 +18,3 @@ yarn install
 (cd ../exo-test && bin/setup && echo 'exo-test √')
 (cd ../exosphere-shared && bin/setup && echo 'exosphere-shared √')
 (node_modules/.bin/build)
-(./bin/build)


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->This should at least fix the issue that is causing all of the tests to fail currently. The `bin/build` script was being used to compile the webpack version of the cli. Seeing as that script no longer exists, this was causing errors.

<!-- tag a few reviewers -->
@kevgo @hugobho 