### PR TITLE
TR: Access service.yml correctly (exo-run)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ node_js:
   - "6"
   - "7"
 
-cache:
-  yarn: true
-  directories:
-    - node_modules
-
 git:
   depth: 2
 

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -18,8 +18,7 @@ require! {
 class ServiceRunner extends EventEmitter
 
   ({@name, @config, @logger}) ->
-    | @config.image  =>  @service-config = yaml.safe-load DockerHelper.get-config(@config.image)
-    | otherwise      =>  @service-config = yaml.safe-load fs.read-file-sync(path.join @config.root, 'service.yml')
+    @service-config = yaml.safe-load @service-configuration-content!
 
 
   start: (done) ~>
@@ -68,6 +67,11 @@ class ServiceRunner extends EventEmitter
         | otherwise       =>
           @logger.log name: @name, text: "Docker image failed to rebuild"
           process.exit exit-code
+
+
+  service-configuration-content: ~>
+    | @config.image  =>  DockerHelper.get-config(@config.image)
+    | otherwise      =>  fs.read-file-sync(path.join @config.root, 'service.yml')
 
 
   shutdown-dependencies: ->

--- a/exo-setup/.travis.yml
+++ b/exo-setup/.travis.yml
@@ -10,6 +10,10 @@ node_js:
   - "6"
   - "7"
 
+cache:
+  yarn: true
+  directories:
+    - node_modules
 
 before_install:
   - npm install exosphere-shared

--- a/exosphere-shared/example-apps/crashing-service/application.yml
+++ b/exosphere-shared/example-apps/crashing-service/application.yml
@@ -6,7 +6,5 @@ services:
   public:
     crasher:
       location: ./crasher
-      docker_image: exospheredev/test-service-that-crashes-on-startup
     runner:
       location: ./runner
-      docker_image: exospheredev/test-service-that-keeps-running

--- a/exosphere-shared/example-apps/external-service/app/application.yml
+++ b/exosphere-shared/example-apps/external-service/app/application.yml
@@ -6,4 +6,3 @@ services:
   public:
     web:
       location: ../web-service
-      docker_image: exospheredev/simple-app-web-service

--- a/exosphere-shared/example-apps/failing-setup/application.yml
+++ b/exosphere-shared/example-apps/failing-setup/application.yml
@@ -6,7 +6,5 @@ services:
   public:
     crasher:
       location: ./crasher
-      docker_image: exospheredev/test-service-that-crashes-on-setup
     runner:
       location: ./runner
-      docker_image: exospheredev/working-setup-script-service

--- a/exosphere-shared/example-apps/running/application.yml
+++ b/exosphere-shared/example-apps/running/application.yml
@@ -6,9 +6,7 @@ services:
   public:
     web:
       location: ./web-server
-      docker_image: exospheredev/test-web-app-server
   private:
     users:
       namespace: mongo
       location: ./mongo-service
-      docker_image: exospheredev/test-mongo-db-service

--- a/exosphere-shared/example-apps/service-crashing-at-runtime/application.yml
+++ b/exosphere-shared/example-apps/service-crashing-at-runtime/application.yml
@@ -6,7 +6,5 @@ services:
   public:
     crasher:
       location: ./crasher
-      docker_image: exospheredev/crasher-service
     runner:
       location: ./runner
-      docker_image: exospheredev/runner-service

--- a/exosphere-shared/example-apps/simple/application.yml
+++ b/exosphere-shared/example-apps/simple/application.yml
@@ -7,4 +7,3 @@ services:
   public:
     web:
       location: ./web
-      docker_image: exospheredev/simple-app-web-server

--- a/exosphere-shared/example-apps/test/application.yml
+++ b/exosphere-shared/example-apps/test/application.yml
@@ -6,12 +6,9 @@ services:
   public:
     web:
       location: ./web-server
-      docker_image: exospheredev/test-app-web-server
   private:
     users:
       location: ./mongo-service
       namespace: mongo
-      docker_image: exospheredev/test-mongo-db-server
     dashboard:
       location: ./dashboard
-      docker_image: exospheredev/dashboard-server

--- a/exosphere-shared/example-apps/tests-failing/application.yml
+++ b/exosphere-shared/example-apps/tests-failing/application.yml
@@ -6,7 +6,5 @@ services:
   public:
     tweets-service:
       location: ./tweets-service
-      docker_image: exospheredev/another-service-with-failing-tests
     users-service:
       location: ./users-service
-      docker_image: exospheredev/a-service-with-failing-tests

--- a/exosphere-shared/example-apps/tests-passing/application.yml
+++ b/exosphere-shared/example-apps/tests-passing/application.yml
@@ -6,7 +6,5 @@ services:
   public:
     tweets-service:
       location: ./tweets-service
-      docker_image: exospheredev/another-service-with-passing-tests
     users-service:
       location: ./users-service
-      docker_image: exospheredev/a-service-with-passing-tests


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #127 

<!-- a short description of the change in addition to what is already mentioned in the issue above -->If the `@config.image` field is valid, it gets `service.yml` from the docker image, otherwise it gets the local version, seeing as these are the only two possibilities currently.

<!-- tag a few reviewers -->
@kevgo @hugobho 