### PR TITLE
Fix breaking changes from exocom

### DIFF
--- a/exo-deploy/src/dockerized/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/dockerized/terraform/aws-terraform-file-builder.ls
@@ -143,7 +143,7 @@ class AwsTerraformFileBuilder
         value: @exocom-dns
       * name: 'EXOCOM_PORT'
         value: "#{@exocom-port}"
-      * name: 'SERVICE_NAME'
+      * name: 'ROLE'
         value: service-name
     for dependency of service-config.dependencies
       switch dependency
@@ -169,7 +169,7 @@ class AwsTerraformFileBuilder
         protocol: 'tcp'
       ]
       environment: [
-        name: 'SERVICE_MESSAGES'
+        name: 'SERVICE_ROUTES'
         value: @_compile-service-messages! |> JSON.stringify
       ]
     ]

--- a/exo-run/features/steps/steps.ls
+++ b/exo-run/features/steps/steps.ls
@@ -62,9 +62,9 @@ module.exports = ->
     @process.wait expected-text, done
 
 
-  @When /^adding a file to the "([^"]*)" service$/ (service-name) ->
+  @When /^adding a file to the "([^"]*)" service$/ (role) ->
     app-config = yaml.safe-load fs.read-file-sync(path.join(app-dir, 'application.yml'), 'utf8')
-    service-config = app-config.services[\public][service-name] or app-config.services[\private][service-name]
+    service-config = app-config.services[\public][role] or app-config.services[\private][role]
     fs.write-file-sync path.join(app-dir, service-config.location, 'test.txt'), 'test'
 
 

--- a/exo-run/features/steps/steps.ls
+++ b/exo-run/features/steps/steps.ls
@@ -103,7 +103,7 @@ module.exports = ->
 
 
   @Then /^my machine is running ExoCom$/ timeout: 10_000, (done) ->
-    @process.wait /exocom  ExoCom \d+\.\d+\.\d+ WebSocket listener online at port/, done
+    @process.wait /exocom  ExoCom WebSocket listener online at port/, done
 
 
   @Then /^my machine is running the services:$/ timeout: 10_000, (table, done) ->

--- a/exo-run/src/app-runner.ls
+++ b/exo-run/src/app-runner.ls
@@ -4,7 +4,7 @@ require! {
   'child_process'
   './docker-runner' : DockerRunner
   'events' : {EventEmitter}
-  '../../exosphere-shared' : {compile-service-messages, DockerHelper}
+  '../../exosphere-shared' : {compile-service-routes, DockerHelper}
   'nitroglycerin' : N
   'port-reservation'
   'path'
@@ -22,19 +22,19 @@ class AppRunner extends EventEmitter
   start-exocom: (done) ->
     port-reservation
       ..get-port N (@exocom-port) ~>
-        service-messages = compile-service-messages @app-config |> JSON.stringify |> (.replace /"/g, '')
+        service-routes = compile-service-routes @app-config |> JSON.stringify |> (.replace /"/g, '')
         @docker-config =
           author: 'originate'
           image: 'exocom'
           app-name: @app-config.name
           start-command: 'bin/exocom'
           env:
-            SERVICE_ROUTES: service-messages
+            SERVICE_ROUTES: service-routes
             PORT: @exocom-port
             ROLE: 'exocom'
           publish:
             EXOCOM_PORT: "#{@exocom-port}:#{@exocom-port}"
-        @exocom = new DockerRunner {name: 'exocom', @docker-config, @logger}
+        @exocom = new DockerRunner {role: 'exocom', @docker-config, @logger}
           ..start-service!
           ..on 'error', (message) ~> @shutdown error-message: message
 
@@ -42,17 +42,17 @@ class AppRunner extends EventEmitter
   start-services: ->
     wait-until (~> @exocom-port), 1, ~>
       @services = []
-      for service-type of @app-config.services
-        for service-name, service-data of @app-config.services[service-type]
+      for protection-type of @app-config.services
+        for role, service-data of @app-config.services[protection-type]
           @services.push do
             {
-              name: service-name
+              role: role
               location: service-data.location
               image: service-data.docker_image
             }
       @runners = {}
       for service in @services
-        @runners[service.name] = new ServiceRunner {service.name, config: {root: path.join(process.cwd!, service.location), EXOCOM_PORT: @exocom-port, image: service.image, app-name: @app-config.name}, @logger}
+        @runners[service.role] = new ServiceRunner {service.role, config: {root: path.join(process.cwd!, service.location), EXOCOM_PORT: @exocom-port, image: service.image, app-name: @app-config.name}, @logger}
           ..on 'error', @shutdown
       async.parallel [runner.start for _, runner of @runners], (err) ~>
         @logger.log name: 'exo-run', text: 'all services online'
@@ -64,8 +64,8 @@ class AppRunner extends EventEmitter
       | otherwise      =>  console.log "\n\n #{close-message}"; exit-code = 0
     DockerHelper.remove-container \exocom
     for service in @services
-      DockerHelper.remove-container service.name
-      @runners[service.name].shutdown-dependencies!
+      DockerHelper.remove-container service.role
+      @runners[service.role].shutdown-dependencies!
     process.exit exit-code
 
 

--- a/exo-run/src/app-runner.ls
+++ b/exo-run/src/app-runner.ls
@@ -29,9 +29,9 @@ class AppRunner extends EventEmitter
           app-name: @app-config.name
           start-command: 'bin/exocom'
           env:
-            SERVICE_MESSAGES: service-messages
+            SERVICE_ROUTES: service-messages
             PORT: @exocom-port
-            SERVICE_NAME: 'exocom'
+            ROLE: 'exocom'
           publish:
             EXOCOM_PORT: "#{@exocom-port}:#{@exocom-port}"
         @exocom = new DockerRunner {name: 'exocom', @docker-config, @logger}

--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -41,7 +41,7 @@ class DockerRunner extends EventEmitter
   _create-run-command: ->
     command = "
       docker run 
-        --name=#{@docker-config.env.SERVICE_NAME} "
+        --name=#{@docker-config.env.ROLE} "
     for name, val of @docker-config.env
       command += " -e #{name}=#{val}"
     for name, port of @docker-config.publish

--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -17,15 +17,15 @@ require! {
 # Runs a docker image
 class DockerRunner extends EventEmitter
 
-  ({@name, @docker-config, @logger}) ->
+  ({@role, @docker-config, @logger}) ->
 
 
   start-service: ->
     unless DockerHelper.image-exists author: @docker-config.author, name: @docker-config.image
-      return @emit 'error', "No Docker image exists for service '#{@name}'. Please run exo-setup."
-    DockerHelper.remove-container @name
+      return @emit 'error', "No Docker image exists for service '#{@role}'. Please run exo-setup."
+    DockerHelper.remove-container @role
 
-    switch @name
+    switch @role
       | \exocom    => @_run-container!
       | otherwise  =>
         wait-until (~> DockerHelper.get-docker-ip 'exocom'), 10, ~>
@@ -35,7 +35,7 @@ class DockerRunner extends EventEmitter
 
 
   write: (text) ~>
-    @logger.log {@name, text, trim: yes}
+    @logger.log {@role, text, trim: yes}
 
 
   _create-run-command: ->
@@ -52,7 +52,7 @@ class DockerRunner extends EventEmitter
 
 
   _on-container-error: ~>
-    @emit 'error', "Service '#{@name}' crashed, shutting down application"
+    @emit 'error', "Service '#{@role}' crashed, shutting down application"
 
 
   _run-container: ~>
@@ -62,7 +62,7 @@ class DockerRunner extends EventEmitter
       ..on 'ended', (exit-code, killed) ~>
         | exit-code > 0 and not killed   =>  @_on-container-error!
       ..wait @docker-config.start-text, ~>
-        @logger.log name: 'exo-run', text: "'#{@name}' is running"
+        @logger.log name: 'exo-run', text: "'#{@role}' is running"
         @emit 'online'
 
 

--- a/exosphere-shared/example-apps/running/web-server/server.ls
+++ b/exosphere-shared/example-apps/running/web-server/server.ls
@@ -3,7 +3,7 @@ require! {
   'exorelay' : ExoRelay
 }
 
-exorelay = new ExoRelay exocom-host: process.env.EXOCOM_HOST, exocom-port: process.env.EXOCOM_PORT, service-name: 'web'
+exorelay = new ExoRelay exocom-host: process.env.EXOCOM_HOST, exocom-port: process.env.EXOCOM_PORT, role: 'web'
   ..on 'online', -> console.log "web service exorelay online"
   ..on 'error', (err) -> console.log "web service exorelay encountered error: #{err}"
   ..connect!

--- a/exosphere-shared/example-apps/test/web-server/server.ls
+++ b/exosphere-shared/example-apps/test/web-server/server.ls
@@ -4,7 +4,7 @@ require! {
 }
 
 
-exorelay = new ExoRelay exocom-port: 8000, service-name: 'web'
+exorelay = new ExoRelay exocom-port: 8000, role: 'web'
   ..on 'online', (port) -> console.log "web service exorelay online at port #{port}"
   ..on 'error', (err) -> console.log "web service exorelay encountered error: #{err}"
   ..listen 8002

--- a/exosphere-shared/src/compile-service-messages.ls
+++ b/exosphere-shared/src/compile-service-messages.ls
@@ -7,11 +7,11 @@ require! {
 module.exports = (app-config, base-path) ->
   service-messages = []
   for type of app-config.services
-    for service-name, service-data of app-config.services["#{type}"]
+    for service-role, service-data of app-config.services["#{type}"]
       service-config = yaml.safe-load fs.read-file-sync(path.join(base-path ? process.cwd!, service-data.location, 'service.yml'), 'utf8')
       service-messages.push do
         {
-          name: service-name
+          roletype: service-role
           receives: service-config.messages.receives
           sends: service-config.messages.sends
           namespace: service-data.namespace

--- a/exosphere-shared/src/compile-service-routes.ls
+++ b/exosphere-shared/src/compile-service-routes.ls
@@ -5,15 +5,15 @@ require! {
 }
 
 module.exports = (app-config, base-path) ->
-  service-messages = []
+  service-routes = []
   for protection-type of app-config.services
     for service-type, service-data of app-config.services["#{protection-type}"]
       service-config = yaml.safe-load fs.read-file-sync(path.join(base-path ? process.cwd!, service-data.location, 'service.yml'), 'utf8')
-      service-messages.push do
+      service-routes.push do
         {
           service-type: service-type
           receives: service-config.messages.receives
           sends: service-config.messages.sends
           namespace: service-data.namespace
         }
-  service-messages
+  service-routes

--- a/exosphere-shared/src/compile-service-routes.ls
+++ b/exosphere-shared/src/compile-service-routes.ls
@@ -6,12 +6,12 @@ require! {
 
 module.exports = (app-config, base-path) ->
   service-messages = []
-  for type of app-config.services
-    for service-role, service-data of app-config.services["#{type}"]
+  for protection-type of app-config.services
+    for service-type, service-data of app-config.services["#{protection-type}"]
       service-config = yaml.safe-load fs.read-file-sync(path.join(base-path ? process.cwd!, service-data.location, 'service.yml'), 'utf8')
       service-messages.push do
         {
-          roletype: service-role
+          service-type: service-type
           receives: service-config.messages.receives
           sends: service-config.messages.sends
           namespace: service-data.namespace

--- a/exosphere-shared/src/index.ls
+++ b/exosphere-shared/src/index.ls
@@ -2,7 +2,7 @@ require! {
   './logger' : Logger
   './docker-helper' : DockerHelper
   './call-args'
-  './compile-service-messages'
+  './compile-service-routes'
   './normalize-path'
   './kill-child-processes'
   'path'
@@ -11,7 +11,7 @@ require! {
 
 module.exports = {
   call-args
-  compile-service-messages
+  compile-service-routes
   Logger
   DockerHelper
   example-apps-path: path.join(__dirname, '..' 'example-apps')

--- a/exosphere-shared/src/logger.ls
+++ b/exosphere-shared/src/logger.ls
@@ -6,7 +6,7 @@ require! {
 
 class Logger
 
-  (service-names = []) ->
+  (roles = []) ->
     @colors =
       exocom: blue
       exorun: reset
@@ -16,7 +16,7 @@ class Logger
       'exo-sync': reset
       'exo-lint': reset
       'exo-deploy': reset
-    @set-colors service-names
+    @set-colors roles
 
 
   log: ({name, text, trim}) ~>
@@ -32,10 +32,10 @@ class Logger
       console.error color(bold "#{@_pad name} "), red(line)
 
   # This method may be called after initialization to set/reset colors,
-  # given a new list of service-names
-  set-colors: (service-names) ->
-    for service-name, i in service-names
-      @colors[service-name] = Logger._default_colors[i % Logger._default_colors.length]
+  # given a new list of roles
+  set-colors: (roles) ->
+    for role, i in roles
+      @colors[role] = Logger._default_colors[i % Logger._default_colors.length]
     @length = map (.length), Object.keys(@colors) |> maximum
 
 

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/steps/steps.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/steps/steps.ls
@@ -22,7 +22,7 @@ module.exports = ->
 
 
   @Given /^an instance of this service$/, (done) ->
-    @process = new ExoService service-name: '_____serviceName_____', exocom-port: @exocom-port, exocom-host: 'localhost'
+    @process = new ExoService role: '_____serviceName_____', exocom-port: @exocom-port, exocom-host: 'localhost'
       ..connect!
       ..on 'online', -> wait 10, done
 

--- a/exosphere-shared/templates/add-service/exoservice-ls/features/steps/steps.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls/features/steps/steps.ls
@@ -23,7 +23,7 @@ module.exports = ->
 
 
   @Given /^an instance of this service$/, (done) ->
-    @process = new ExoService service-name: service-config.name, exocom-port: @exocom-port, exocom-host: 'localhost'
+    @process = new ExoService role: service-config.name, exocom-port: @exocom-port, exocom-host: 'localhost'
       ..connect!
       ..on 'online', ~> wait 10, done
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/app/index.js
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/app/index.js
@@ -13,12 +13,12 @@ const port = process.env.PORT || 3000
 
 
 function startExorelay (done) {
-  global.exorelay = new ExoRelay({serviceName: process.env.SERVICE_NAME,
+  global.exorelay = new ExoRelay({serviceName: process.env.ROLE,
                                   exocomHost: process.env.EXOCOM_HOST,
                                   exocomPort: process.env.EXOCOM_PORT})
   global.exorelay.on('error', (err) => { console.log(red(err)) })
   global.exorelay.on('online', (port) => {
-    console.log(`${green('ExoRelay')} for '${process.env.SERVICE_NAME}' online at port ${cyan(port)}`)
+    console.log(`${green('ExoRelay')} for '${process.env.ROLE}' online at port ${cyan(port)}`)
     done()
   })
   global.exorelay.connect()

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/app/index.ls
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/app/index.ls
@@ -14,10 +14,10 @@ require! {
 
 
 start-exorelay = (done) ->
-  global.exorelay = new ExoRelay service-name: process.env.SERVICE_NAME, exocom-host: process.env.EXOCOM_HOST, exocom-port: process.env.EXOCOM_PORT
+  global.exorelay = new ExoRelay role: process.env.ROLE, exocom-host: process.env.EXOCOM_HOST, exocom-port: process.env.EXOCOM_PORT
     ..on 'error', (err) -> console.log red err
     ..on 'online', (port) ->
-      console.log "#{green 'ExoRelay'} for '#{process.env.SERVICE_NAME}' online at port #{cyan port}"
+      console.log "#{green 'ExoRelay'} for '#{process.env.ROLE}' online at port #{cyan port}"
       done!
     ..connect!
 

--- a/website/tutorial/part_2/part_2a/code_04/todo-app/html-server/app/index.js
+++ b/website/tutorial/part_2/part_2a/code_04/todo-app/html-server/app/index.js
@@ -11,7 +11,7 @@ const port = process.env.PORT || 3000
 
 
 function startExorelay (done) {
-  global.exorelay = new ExoRelay({serviceName: process.env.SERVICE_NAME,
+  global.exorelay = new ExoRelay({serviceName: process.env.ROLE,
                                   exocomPort: process.env.EXOCOM_PORT})
   global.exorelay.on('error', (err) => { console.log(red(err)) })
   global.exorelay.on('online', (port) => {

--- a/website/tutorial/part_2/part_2a/code_08/todo-app/web/app/index.js
+++ b/website/tutorial/part_2/part_2a/code_08/todo-app/web/app/index.js
@@ -11,7 +11,7 @@ const port = process.env.PORT || 3000
 
 
 function startExorelay (done) {
-  global.exorelay = new ExoRelay({serviceName: process.env.SERVICE_NAME,
+  global.exorelay = new ExoRelay({serviceName: process.env.ROLE,
                                   exocomPort: process.env.EXOCOM_PORT})
   global.exorelay.on('error', (err) => { console.log(red(err)) })
   global.exorelay.on('online', (port) => {

--- a/website/tutorial/part_2/part_2a/code_09/todo-app/web/app/index.js
+++ b/website/tutorial/part_2/part_2a/code_09/todo-app/web/app/index.js
@@ -11,7 +11,7 @@ const port = process.env.PORT || 3000
 
 
 function startExorelay (done) {
-  global.exorelay = new ExoRelay({serviceName: process.env.SERVICE_NAME,
+  global.exorelay = new ExoRelay({serviceName: process.env.ROLE,
                                   exocomPort: process.env.EXOCOM_PORT})
   global.exorelay.on('error', (err) => { console.log(red(err)) })
   global.exorelay.on('online', (port) => {


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #118 

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Renames some of the variables to reflect what they now are in the exocom monorepo.
Additionally removes the regex for the exocom version from the exo-run feature test. 

Tests will currently fail until the new versions of the exocom repos are published.

<!-- tag a few reviewers -->
@kevgo 