### PR TITLE
Fix logger use in exo-setup

### DIFF
--- a/exo-setup/src/app-setup.ls
+++ b/exo-setup/src/app-setup.ls
@@ -22,11 +22,9 @@ class AppSetup extends EventEmitter
             location: service-data.location
     setups = for service in @services
       new ServiceSetup role: service.role, logger: @logger, config: root: path.join(process.cwd!, service.location)
-        ..on 'output', (data) ~> @emit 'output', data
 
     docker-setups = for service in @services
       new DockerSetup role: service.role, logger: @logger, config: root: path.join(process.cwd!, service.location)
-        ..on 'output', (data) ~> @emit 'output', data
 
     # Note: Windows does not provide atomic file operations,
     #       causing file system permission errors when multiple threads read and write to the same cache directory.

--- a/exo-setup/src/cli.ls
+++ b/exo-setup/src/cli.ls
@@ -13,5 +13,4 @@ module.exports = ->
   console.log "Setting up #{green app-config.name} #{cyan app-config.version}\n"
   logger = new Logger flatten [Object.keys(app-config.services[type]) for type of app-config.services]
   app-setup = new AppSetup app-config: app-config, logger: logger
-    ..on 'output', (data) -> data.text = data.text.replace('\n', '') ; logger.log data
     ..start-setup!

--- a/exo-setup/src/docker-setup.ls
+++ b/exo-setup/src/docker-setup.ls
@@ -45,7 +45,7 @@ class DockerSetup extends EventEmitter
 
 
   write: (text) ~>
-    @emit 'output', {@role, text, trim: yes}
+    @logger.log {name: @role, text, trim: yes}
 
 
 

--- a/exo-setup/src/exocom-setup.ls
+++ b/exo-setup/src/exocom-setup.ls
@@ -27,7 +27,7 @@ class ExocomSetup extends EventEmitter
 
 
   write: (text) ~>
-    @emit 'output', {@name, text, trim: yes}
+    @logger.log {@name, text, trim: yes}
 
 
 

--- a/exo-setup/src/service-setup.ls
+++ b/exo-setup/src/service-setup.ls
@@ -30,7 +30,7 @@ class ServiceSetup extends EventEmitter
 
 
   write: (text) ~>
-    @emit 'output', {@role, text}
+    @logger.log {name: @role, text, trim: yes}
 
 
 


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
`exo-setup` was not fully utilizing the injected `logger` object.

<!-- tag a few reviewers -->
@kevgo