### PR TITLE
Update example apps and template's dependencies

### DIFF
--- a/exosphere-shared/example-apps/running/mongo-service/package.json
+++ b/exosphere-shared/example-apps/running/mongo-service/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for testing only, do not publish",
   "dependencies": {
-    "exoservice": "0.17.4"
+    "exoservice": "0.18.1"
   },
   "devDependencies": {
     "david": "9.0.0",

--- a/exosphere-shared/example-apps/running/mongo-service/package.json
+++ b/exosphere-shared/example-apps/running/mongo-service/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for testing only, do not publish",
   "dependencies": {
-    "exoservice": "0.18.1"
+    "exoservice": "0.18.2"
   },
   "devDependencies": {
     "david": "9.0.0",

--- a/exosphere-shared/example-apps/running/web-server/package.json
+++ b/exosphere-shared/example-apps/running/web-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "author": "Kevin Goslar",
   "dependencies": {
-    "exorelay": "0.19.5",
+    "exorelay": "0.20.0",
     "livescript": "1.5.0"
   },
   "description": "Example app that is running",

--- a/exosphere-shared/example-apps/test/dashboard/package.json
+++ b/exosphere-shared/example-apps/test/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for testing only, do not publish",
   "dependencies": {
-    "exoservice": "0.18.1"
+    "exoservice": "0.18.2"
   },
   "devDependencies": {
     "o-tools": "0.6.0"

--- a/exosphere-shared/example-apps/test/dashboard/package.json
+++ b/exosphere-shared/example-apps/test/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for testing only, do not publish",
   "dependencies": {
-    "exoservice": "0.17.4"
+    "exoservice": "0.18.1"
   },
   "devDependencies": {
     "o-tools": "0.6.0"

--- a/exosphere-shared/example-apps/test/mongo-service/package.json
+++ b/exosphere-shared/example-apps/test/mongo-service/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for testing only, do not publish",
   "dependencies": {
-    "exoservice": "0.18.1"
+    "exoservice": "0.18.2"
   },
   "devDependencies": {
     "o-tools": "0.6.0"

--- a/exosphere-shared/example-apps/test/mongo-service/package.json
+++ b/exosphere-shared/example-apps/test/mongo-service/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for testing only, do not publish",
   "dependencies": {
-    "exoservice": "0.17.4"
+    "exoservice": "0.18.1"
   },
   "devDependencies": {
     "o-tools": "0.6.0"

--- a/exosphere-shared/example-apps/test/web-server/package.json
+++ b/exosphere-shared/example-apps/test/web-server/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "exorelay": "0.19.5",
+    "exorelay": "0.20.0",
     "livescript": "^1.4.0"
   },
   "devDependencies": {

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/steps/steps.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/steps/steps.js
@@ -22,7 +22,7 @@ module.exports = function() {
 
 
   this.Given(/^an instance of this service$/, function(done) {
-    this.process = new ExoService({ serviceRole: '_____serviceRole_____',
+    this.process = new ExoService({ role: '_____serviceRole_____',
                                     exocomHost: 'localhost',
                                     exocomPort: this.exocomPort})
     this.process.connect()

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.17.5",
+    "exoservice": "0.18.1",
     "get-env": "0.5.10",
     "mongodb": "2.2.16"
   },
@@ -14,7 +14,7 @@
     "dependency-lint": "4.3.1",
     "dim-console": "0.4.4",
     "ejs": "2.5.5",
-    "exocom-mock": "0.9.4",
+    "exocom-mock": "0.10.0",
     "fs-extra": "1.0.0",
     "js-yaml": "3.7.0",
     "jsdiff-console": "2.2.1",

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.18.1",
+    "exoservice": "0.18.2",
     "get-env": "0.5.10",
     "mongodb": "2.2.16"
   },

--- a/exosphere-shared/templates/add-service/exoservice-es6/features/steps/steps.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6/features/steps/steps.js
@@ -23,7 +23,7 @@ module.exports = function() {
 
 
   this.Given(/^an instance of this service$/, function(done) {
-    this.process = new ExoService({ serviceRole: serviceConfig.name,
+    this.process = new ExoService({  role: serviceConfig.type
                                      exocomPort: this.exocomPort,
                                      exocomHost: 'localhost' })
     this.process.connect()

--- a/exosphere-shared/templates/add-service/exoservice-es6/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-es6/package.json
@@ -2,14 +2,14 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.17.5"
+    "exoservice": "0.18.1"
   },
   "description": "_____description_____",
   "devDependencies": {
     "chai": "3.5.0",
     "cucumber": "1.3.1",
     "dependency-lint": "4.3.1",
-    "exocom-mock": "0.9.4",
+    "exocom-mock": "0.10.0",
     "fs-extra": "1.0.0",
     "js-yaml": "3.7.0",
     "jsdiff-console": "2.2.1",

--- a/exosphere-shared/templates/add-service/exoservice-es6/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-es6/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.18.1"
+    "exoservice": "0.18.2"
   },
   "description": "_____description_____",
   "devDependencies": {

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.18.1",
+    "exoservice": "0.18.2",
     "get-env": "0.5.10",
     "mongodb": "2.2.16"
   },

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.17.5",
+    "exoservice": "0.18.1",
     "get-env": "0.5.10",
     "mongodb": "2.2.16"
   },
@@ -12,7 +12,7 @@
     "cucumber": "1.3.1",
     "cucumber-snippets-livescript": "1.0.1",
     "eco": "1.1.0-rc-3",
-    "exocom-mock": "0.9.4",
+    "exocom-mock": "0.10.0",
     "fs-extra": "1.0.0",
     "js-yaml": "3.7.0",
     "jsdiff-console": "2.2.1",

--- a/exosphere-shared/templates/add-service/exoservice-ls/features/steps/steps.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls/features/steps/steps.ls
@@ -23,14 +23,14 @@ module.exports = ->
 
 
   @Given /^an instance of this service$/, (done) ->
-    @process = new ExoService role: service-config.name, exocom-port: @exocom-port, exocom-host: 'localhost'
+    @process = new ExoService role: service-config.type, exocom-port: @exocom-port, exocom-host: 'localhost'
       ..connect!
       ..on 'online', ~> wait 10, done
 
 
   @When /^receiving the "([^"]*)" command$/, (commandName) ->
     @exocom.reset!
-    @exocom.send service: service-config.name, name: command-name
+    @exocom.send service: service-config.type, name: command-name
 
 
   @Then /^this service replies with a "([^"]*)" message/, (expectedMessageName, done) ->

--- a/exosphere-shared/templates/add-service/exoservice-ls/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-ls/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.17.5"
+    "exoservice": "0.18.1"
   },
   "description": "_____description_____",
   "devDependencies": {
@@ -10,7 +10,7 @@
     "cucumber": "1.3.1",
     "cucumber-snippets-livescript": "1.0.1",
     "dependency-lint": "4.3.1",
-    "exocom-mock": "0.9.4",
+    "exocom-mock": "0.10.0",
     "fs-extra": "1.0.0",
     "js-yaml": "3.7.0",
     "jsdiff-console": "2.2.1",

--- a/exosphere-shared/templates/add-service/exoservice-ls/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-ls/package.json
@@ -2,7 +2,7 @@
   "name": "_____serviceRole_____",
   "version": "0.0.1",
   "dependencies": {
-    "exoservice": "0.18.1"
+    "exoservice": "0.18.2"
   },
   "description": "_____description_____",
   "devDependencies": {

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/app/index.js
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/app/index.js
@@ -13,7 +13,7 @@ const port = process.env.PORT || 3000
 
 
 function startExorelay (done) {
-  global.exorelay = new ExoRelay({serviceRole: process.env.ROLE,
+  global.exorelay = new ExoRelay({role: process.env.ROLE,
                                   exocomHost: process.env.EXOCOM_HOST,
                                   exocomPort: process.env.EXOCOM_PORT})
   global.exorelay.on('error', (err) => { console.log(red(err)) })

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/package.json
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/package.json
@@ -7,7 +7,7 @@
     "chalk": "1.1.3",
     "cookie-parser": "1.4.3",
     "css-loader": "0.26.1",
-    "exorelay": "0.19.5",
+    "exorelay": "0.20.0",
     "express": "4.14.0",
     "exprestive": "1.3.0",
     "jade": "1.11.0",

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/package.json
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/package.json
@@ -7,7 +7,7 @@
     "chalk": "1.1.3",
     "cookie-parser": "1.4.3",
     "css-loader": "0.26.1",
-    "exorelay": "0.19.5",
+    "exorelay": "0.20.0",
     "express": "4.14.0",
     "exprestive": "1.3.0",
     "jade": "1.11.0",


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
The example apps and templates now use the latest published versions of exorelay and exoservice.

<!-- tag a few reviewers -->
@kevgo 