### PR TITLE
Compile docker run command in individual lines

### DIFF
--- a/exo-run/src/docker-runner.ls
+++ b/exo-run/src/docker-runner.ls
@@ -38,16 +38,13 @@ class DockerRunner extends EventEmitter
 
 
   _create-run-command: ->
-    command = "
-      docker run 
-        --name=#{@docker-config.env.ROLE} "
+    command = "docker run --name=#{@docker-config.env.ROLE} "
     for name, val of @docker-config.env
       command += " -e #{name}=#{val}"
     for name, port of @docker-config.publish
       command += " --publish #{port}"
-    command += " 
-      #{@docker-config.author}/#{@docker-config.image} 
-      #{@docker-config.start-command}"
+    command += " #{@docker-config.author}/#{@docker-config.image}"
+    command += " #{@docker-config.start-command}"
 
 
   _on-container-error: ~>


### PR DESCRIPTION
Previously, when compiling a docker command string like so: 

```
command = "
  docker run
    --name=#{some-name}"
```
my editor would always remove the white space so I would have problems with `exo run` trying to execute an improperly spaced command (i.e. `docker run--name=some-name`). This PR gets rid of that issue, but it is only a temporary fix.

In the future, we will be using a docker runner class that will avoid this problem of manually compiling docker commands altogether.

@kevgo 