### PR TITLE
Keep "version" variable

### DIFF
--- a/exo-setup/src/exocom-setup.ls
+++ b/exo-setup/src/exocom-setup.ls
@@ -13,7 +13,8 @@ class ExocomSetup extends EventEmitter
 
 
   start: ~>
-    if DockerHelper.image-exists author: \originate, name: \exocom, version: @app-config.bus.version
+    version = @app-config.bus.version
+    if DockerHelper.image-exists author: \originate, name: \exocom, version: version
       @logger.log role: @name, text: 'ExoCom image already up to date'
       return
     @logger.log role: @name, text: "Pulling ExoCom image version #{version}"


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
In a previous PR I had inlined `version`, but as it turns out it is used in 3 other places in the same function.
<!-- tag a few reviewers -->
@kevgo 