### PR TITLE
Remove exo-create timeout

### DIFF
--- a/exo-create/features/steps/steps-when.ls
+++ b/exo-create/features/steps/steps-when.ls
@@ -10,7 +10,7 @@ require! {
 
 module.exports = ->
 
-  @When /^executing "([^"]*)"$/, timeout: 20_000, (command, done) ->
+  @When /^executing "([^"]*)"$/, (command, done) ->
     @process = new ObservableProcess(call-args(path.join process.cwd!, 'bin', command),
                                  cwd: @app-dir,
                                  stdout: dim-console.process.stdout


### PR DESCRIPTION
Turns out I had `node_modules` installed for each of the service templates which is why it took so long to add a service.
:man_facepalming: 

@kevgo 