### PR TITLE
Use dashes in service types

### DIFF
--- a/exosphere-shared/example-apps/app-with-external-docker-images/local-service/service.yml
+++ b/exosphere-shared/example-apps/app-with-external-docker-images/local-service/service.yml
@@ -1,4 +1,4 @@
-title: simple app web server
+type: simple-app-web-server
 description: says hello to the world, ignores .txt files when file watching
 author: exospheredev
 

--- a/exosphere-shared/example-apps/crashing-service/crasher/service.yml
+++ b/exosphere-shared/example-apps/crashing-service/crasher/service.yml
@@ -1,4 +1,4 @@
-type: test service that crashes on startup
+type: test-service-that-crashes-on-startup
 description: generic MongoDB storage service
 author: exospheredev
 

--- a/exosphere-shared/example-apps/crashing-service/runner/service.yml
+++ b/exosphere-shared/example-apps/crashing-service/runner/service.yml
@@ -1,4 +1,4 @@
-type: test service that keeps running
+type: test-service-that-keeps-running
 description: generic MongoDB storage service
 author: exospheredev
 

--- a/exosphere-shared/example-apps/external-service/web-service/service.yml
+++ b/exosphere-shared/example-apps/external-service/web-service/service.yml
@@ -1,4 +1,4 @@
-type: simple app web service
+type: simple-app-web-service
 description: An external web service that requires no setup
 author: exospheredev
 

--- a/exosphere-shared/example-apps/failing-setup/crasher/service.yml
+++ b/exosphere-shared/example-apps/failing-setup/crasher/service.yml
@@ -1,4 +1,4 @@
-type: test service that crashes on setup
+type: test-service-that-crashes-on-setup
 description: setup script returns error code 3
 author: exospheredev
 

--- a/exosphere-shared/example-apps/failing-setup/runner/service.yml
+++ b/exosphere-shared/example-apps/failing-setup/runner/service.yml
@@ -1,4 +1,4 @@
-type: working setup script service
+type: working-setup-script-service
 description: setup scripts succeeds
 author: exospheredev
 

--- a/exosphere-shared/example-apps/running/mongo-service/service.yml
+++ b/exosphere-shared/example-apps/running/mongo-service/service.yml
@@ -1,4 +1,4 @@
-type: test mongoDB service
+type: test-mongoDB-service
 description: generic mongoDB storage service
 author: exospheredev
 

--- a/exosphere-shared/example-apps/running/web-server/service.yml
+++ b/exosphere-shared/example-apps/running/web-server/service.yml
@@ -1,4 +1,4 @@
-type: test web app server
+type: test-web-app-server
 description: serves simple HTML pages as part of the test app
 author: exospheredev
 

--- a/exosphere-shared/example-apps/service-crashing-at-runtime/crasher/service.yml
+++ b/exosphere-shared/example-apps/service-crashing-at-runtime/crasher/service.yml
@@ -1,4 +1,4 @@
-type: crasher service
+type: crasher-service
 description: crashes on server request
 author: exospheredev
 

--- a/exosphere-shared/example-apps/service-crashing-at-runtime/runner/service.yml
+++ b/exosphere-shared/example-apps/service-crashing-at-runtime/runner/service.yml
@@ -1,4 +1,4 @@
-type: runner service
+type: runner-service
 description: runs without crashing
 author: exospheredev
 

--- a/exosphere-shared/example-apps/simple/web/service.yml
+++ b/exosphere-shared/example-apps/simple/web/service.yml
@@ -1,4 +1,4 @@
-type: simple app web server
+type: simple-app-web-server
 description: says hello to the world, ignores .txt files when file watching
 author: exospheredev
 

--- a/exosphere-shared/example-apps/test/dashboard/service.yml
+++ b/exosphere-shared/example-apps/test/dashboard/service.yml
@@ -1,4 +1,4 @@
-type: dashboard server
+type: dashboard-server
 description: shows a dashboard of the application
 author: exospheredev
 

--- a/exosphere-shared/example-apps/test/mongo-service/service.yml
+++ b/exosphere-shared/example-apps/test/mongo-service/service.yml
@@ -1,4 +1,4 @@
-type: test MongoDB server
+type: test-MongoDB-server
 description: generic MongoDB storage service
 author: exospheredev
 

--- a/exosphere-shared/example-apps/test/web-server/service.yml
+++ b/exosphere-shared/example-apps/test/web-server/service.yml
@@ -1,4 +1,4 @@
-type: test app web server
+type: test-app-web-server
 description: serves simple HTML pages as part of the test app
 author: exospheredev
 

--- a/exosphere-shared/example-apps/tests-failing/tweets-service/service.yml
+++ b/exosphere-shared/example-apps/tests-failing/tweets-service/service.yml
@@ -1,5 +1,5 @@
-type: another service with failing tests
-description: has some feature specs
+type: failing-tests-service-2
+description: has some failing feature specs
 author: exospheredev
 
 setup: echo 'setting up the tweets service'

--- a/exosphere-shared/example-apps/tests-failing/users-service/service.yml
+++ b/exosphere-shared/example-apps/tests-failing/users-service/service.yml
@@ -1,5 +1,5 @@
-type: a service with failing tests
-description: has some feature specs
+type: failing-tests-service-1
+description: has some failing feature specs
 author: exospheredev
 
 setup: echo 'setting up the users service'

--- a/exosphere-shared/example-apps/tests-passing/tweets-service/service.yml
+++ b/exosphere-shared/example-apps/tests-passing/tweets-service/service.yml
@@ -1,5 +1,5 @@
-type: another service with passing tests
-description: has some feature specs
+type: passing-tests-service-2
+description: has some passing feature specs
 author: exospheredev
 
 setup: echo 'setting up the tweets service'

--- a/exosphere-shared/example-apps/tests-passing/users-service/service.yml
+++ b/exosphere-shared/example-apps/tests-passing/users-service/service.yml
@@ -1,5 +1,5 @@
-type: a service with passing tests
-description: has some feature specs
+type: passing-tests-service-1
+description: has some passing feature specs
 author: exospheredev
 
 setup: echo 'setting up the users service'


### PR DESCRIPTION
Service type is sent along as an environment variable to ExoCom in the Docker run command: 
```
docker run -e SERVICE_ROUTES:[{service-type: users-service, sends:.., receives..}]
```
Docker cannot parse the run command if there are spaces.

@kevgo 

