### PR TITLE
Wait for local setups to finish before docker setups start

### DIFF
--- a/exo-setup/src/app-setup.ls
+++ b/exo-setup/src/app-setup.ls
@@ -1,5 +1,6 @@
 require! {
   'async'
+  'chalk' : {red}
   './docker-setup' : DockerSetup
   'events' : {EventEmitter}
   './exocom-setup' : ExocomSetup
@@ -27,6 +28,7 @@ class AppSetup extends EventEmitter
         new ServiceSetup role: service.role, logger: @logger, config: root: path.join(process.cwd!, service.location)
           ..on 'output', (data) ~> @emit 'output', data
     async.map-series setups, (-> &0.start &1), (err) ~>
+      throw new Error red err if err
 
       docker-setups = for service in @services
         new DockerSetup do
@@ -45,6 +47,7 @@ class AppSetup extends EventEmitter
       else
         async.map
       operation docker-setups, (-> &0.start &1), (err) ~>
+        throw new Error red err if err
         @logger.log role: 'exo-setup', text: 'setup complete'
 
     new ExocomSetup @app-config, @logger

--- a/exo-setup/src/app-setup.ls
+++ b/exo-setup/src/app-setup.ls
@@ -28,7 +28,7 @@ class AppSetup extends EventEmitter
         new ServiceSetup role: service.role, logger: @logger, config: root: path.join(process.cwd!, service.location)
           ..on 'output', (data) ~> @emit 'output', data
     async.map-series setups, (-> &0.start &1), (err) ~>
-      throw new Error red err if err
+      | err  =>  throw new Error err
 
       docker-setups = for service in @services
         new DockerSetup do
@@ -47,7 +47,7 @@ class AppSetup extends EventEmitter
       else
         async.map
       operation docker-setups, (-> &0.start &1), (err) ~>
-        throw new Error red err if err
+        | err  =>  throw new Error err
         @logger.log role: 'exo-setup', text: 'setup complete'
 
     new ExocomSetup @app-config, @logger


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #162 

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
exo-setup was running the local setups using `async.map-series` and then going straight into starting the docker setups, and when the docker-setups all finished we were printing `setup complete`.  This change makes the docker-setup work occur after the local setups have already completed.

<!-- tag a few reviewers -->
@kevgo @hugobho 