### PR TITLE
Move 'remove-all-containers' to DockerHelper

### DIFF
--- a/cli/features/support/env.ls
+++ b/cli/features/support/env.ls
@@ -1,6 +1,6 @@
 require! {
   'child_process'
-  '../../../exosphere-shared' : {kill-child-processes}
+  '../../../exosphere-shared' : {kill-child-processes, DockerHelper}
   'fs-extra' : fs
 }
 
@@ -18,8 +18,4 @@ module.exports = ->
 
   #stop and remove all running docker containers
   @After tags: ['~@docker-cleanup'], timeout: 20_000, (scenario, done) ->
-    running-containers = child_process.exec-sync 'docker ps -q' |> (.to-string!)
-    if running-containers
-      child_process.exec 'docker rm $(docker stop $(docker ps -q))', done
-    else
-      done!
+    DockerHelper.remove-all-containers done

--- a/cli/features/support/env.ls
+++ b/cli/features/support/env.ls
@@ -17,5 +17,5 @@ module.exports = ->
 
 
   #stop and remove all running docker containers
-  @After tags: ['~@docker-cleanup'], timeout: 20_000, (scenario, done) ->
-    DockerHelper.remove-all-containers done
+  @After tags: ['~@docker-cleanup'], timeout: 20_000, (scenario) ->
+    DockerHelper.remove-all-containers

--- a/cli/features/support/env.ls
+++ b/cli/features/support/env.ls
@@ -18,4 +18,4 @@ module.exports = ->
 
   #stop and remove all running docker containers
   @After tags: ['~@docker-cleanup'], timeout: 20_000, (scenario) ->
-    DockerHelper.remove-all-containers
+    DockerHelper.remove-all-containers!

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -58,7 +58,7 @@ class DockerHelper
     child_process.exec-sync("docker images #{image.author}/#{image.name}#{if image.version then ":#{image.version}" else ""}", "utf-8") |> (.includes "#{image.author}/#{image.name}")
 
 
-  @remove-all-containers = (done) ->
+  @remove-all-containers = ->
     all-containers = child_process.exec-sync 'docker ps -aq' |> (.to-string!)
     if all-containers
       child_process.exec-sync 'docker rm -f $(docker ps -aq)'

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -61,9 +61,7 @@ class DockerHelper
   @remove-all-containers = (done) ->
     all-containers = child_process.exec-sync 'docker ps -aq' |> (.to-string!)
     if all-containers
-      child_process.exec 'docker rm -f $(docker ps -aq)', done
-    else
-      done!
+      child_process.exec-sync 'docker rm -f $(docker ps -aq)'
 
 
 

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -58,7 +58,7 @@ class DockerHelper
     child_process.exec-sync("docker images #{image.author}/#{image.name}#{if image.version then ":#{image.version}" else ""}", "utf-8") |> (.includes "#{image.author}/#{image.name}")
 
 
-  @remove-all-containers = (done) ~>
+  @remove-all-containers = (done) ->
     all-containers = child_process.exec-sync 'docker ps -aq' |> (.to-string!)
     if all-containers
       child_process.exec 'docker rm -f $(docker ps -aq)', done

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -58,5 +58,13 @@ class DockerHelper
     child_process.exec-sync("docker images #{image.author}/#{image.name}#{if image.version then ":#{image.version}" else ""}", "utf-8") |> (.includes "#{image.author}/#{image.name}")
 
 
+  @remove-all-containers = (done) ~>
+    all-containers = child_process.exec-sync 'docker ps -aq' |> (.to-string!)
+    if all-containers
+      child_process.exec 'docker rm -f $(docker ps -aq)', done
+    else
+      done!
+
+
 
 module.exports = DockerHelper


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #165 

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Moves the function being used in `cli/features/support/env.ls` to exosphere-shared's `DockerHelper`. Additionally, modifies the function to remove **all** containers instead of just those that are currently running.

<!-- tag a few reviewers -->
@kevgo @hugobho 