### PR TITLE
HH-1: Include provider.tf file

### DIFF
--- a/exo-deploy/.gitignore
+++ b/exo-deploy/.gitignore
@@ -1,4 +1,3 @@
-provider.tf
 terraform.tfstate
 terraform.tfstate.backup
 .terraform/

--- a/exo-deploy/templates/aws-terraform/provider.tf
+++ b/exo-deploy/templates/aws-terraform/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+    access_key = "{{access-key}}"
+    secret_key = "{{secret-key}}"
+    region = "{{region}}"
+}


### PR DESCRIPTION
Previously, `provider.tf` was in .gitignore because it actually contained AWS credentials. Now, it serves as a template and that information is rendered in. 

@kevgo @trushton 