### PR TITLE
HH-2: exo-deploy: shorten module names

### DIFF
--- a/exo-deploy/src/dockerized/terraform/aws-terraform-file-builder.ls
+++ b/exo-deploy/src/dockerized/terraform/aws-terraform-file-builder.ls
@@ -109,7 +109,7 @@ class AwsTerraformFileBuilder
 
   _build-service-container-definition: (service-role, image-name, service-config) ->
     container-definition = [
-      name: "exosphere-#{service-role}-service"
+      name: "#{service-role}"
       image: image-name
       cpu: service-config.production.aws.cpu
       memory: service-config.production.aws.memory

--- a/exo-deploy/templates/aws-terraform/private-service.tf
+++ b/exo-deploy/templates/aws-terraform/private-service.tf
@@ -1,8 +1,8 @@
 
-module "{{name}}-service" {
+module "{{name}}" {
   source = "./private-services"
 
-  name = "exosphere-{{name}}-service"
+  name = "{{name}}"
   cluster_id = "${module.public-cluster.cluster_id}"
   security_groups = "${aws_security_group.public.id}"
   subnet_ids = "${module.vpc.public_subnet_id}" /* TODO: make private */

--- a/exo-deploy/templates/aws-terraform/public-service.tf
+++ b/exo-deploy/templates/aws-terraform/public-service.tf
@@ -1,8 +1,8 @@
 
-module "{{name}}-service" {
+module "{{name}}" {
   source = "./public-services"
 
-  name = "exosphere-{{name}}-service"
+  name = "{{name}}"
   cluster_id = "${module.public-cluster.cluster_id}"
   security_groups = "${aws_security_group.public.id}"
   subnet_ids = "${module.vpc.public_subnet_id}"
@@ -16,8 +16,8 @@ resource "aws_route53_record" "{{name}}" {
   type = "A"
 
   alias {
-  name = "${module.{{name}}-service.elb_dns_name}"
-  zone_id = "${module.{{name}}-service.elb_zone_id}"
+  name = "${module.{{name}}.elb_dns_name}"
+  zone_id = "${module.{{name}}.elb_zone_id}"
   evaluate_target_health = true
   }
 }


### PR DESCRIPTION
AWS was complaining that resource names could not exceed 32 characters. 

Plus, we were running into a situation if a service name is `exosphere-users-service`, then `exosphere-#{service-name}-service` was yielding `exosphere-exosphere-users-service-service`.

@kevgo 
@trushton 