### PR TITLE
Set logger colors correctly in exo-test

### DIFF
--- a/exo-test/src/cli.ls
+++ b/exo-test/src/cli.ls
@@ -5,6 +5,7 @@ require! {
   'js-yaml' : yaml
   '../../exosphere-shared' : {Logger}
   'path'
+  'prelude-ls' : {flatten}
   './service-tester' : ServiceTester
 }
 
@@ -37,7 +38,7 @@ function test-service
 
 function test-app
   app-config = yaml.safe-load fs.read-file-sync('application.yml', 'utf8')
-  logger = new Logger Object.keys(app-config.services)
+  logger = new Logger flatten [Object.keys(app-config.services[protection-level]) for protection-level of app-config.services]
     ..log role: 'exo-test', text: "Testing application '#{app-config.name}'"
   app-tester = new AppTester {app-config, logger}
     ..start-testing!


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
`exo-test` had not had its logger updated since we added the `public` and `private` fields to `application.yml`, so colors were not being set for each of the services correctly.

<!-- tag a few reviewers -->
@kevgo @hugobho 