### PR TITLE
Only push local services

### DIFF
--- a/exo-deploy/src/docker-hub.ls
+++ b/exo-deploy/src/docker-hub.ls
@@ -39,11 +39,11 @@ class DockerHub
     names = []
     for service-type of @app-config.services
       for name, config of @app-config.services[service-type]
-        service-config = yaml.safe-load fs.read-file-sync(path.join(process.cwd!, config.location, 'service.yml'), 'utf8')
-        names.push do
-          author: service-config.author
-          name: dashify service-config.type
-          #TODO: get image name if location is docker on dockerhub
+        if config.location
+          service-config = yaml.safe-load fs.read-file-sync(path.join(process.cwd!, config.location, 'service.yml'), 'utf8')
+          names.push do
+            author: service-config.author
+            name: dashify service-config.type
     names
 
 

--- a/exo-deploy/src/docker-hub.ls
+++ b/exo-deploy/src/docker-hub.ls
@@ -39,7 +39,7 @@ class DockerHub
     names = []
     for service-type of @app-config.services
       for name, config of @app-config.services[service-type]
-        if config.location
+        | !config.location  =>  continue
           service-config = yaml.safe-load fs.read-file-sync(path.join(process.cwd!, config.location, 'service.yml'), 'utf8')
           names.push do
             author: service-config.author


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves [#228](https://github.com/Originate/exosphere-sdk/issues/228)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
When compiling the list of images to push to dockerhub, we now check that the service has the `location` field in `application.yml`, indicating that it is a local service that can be pushed.

<!-- tag a few reviewers -->
@kevgo @hugobho 