### PR TITLE
Print correct package version

### DIFF
--- a/cli/src/cli.ls
+++ b/cli/src/cli.ls
@@ -12,7 +12,7 @@ require! {
   '../../exo-test' : test
   'fs'
   'prelude-ls' : {map}
-  '../package.json' : pkg
+  '../../package.json' : pkg
   'path'
   'update-notifier'
 }


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Running `exo version` was printing the version number from `cli/package.json` (which was 0.9.0), whereas we should actually be printing the version number from the exosphere root directory

<!-- tag a few reviewers -->
@kevgo @hugobho 