### PR TITLE
exo-create: Use pkg.version as default exocom version

### DIFF
--- a/exo-create/src/entities/application.ls
+++ b/exo-create/src/entities/application.ls
@@ -6,6 +6,7 @@ require! {
   'path'
   'prelude-ls': {empty}
   'tmplconv'
+  '../../../package.json' : pkg
 }
 
 application = ->
@@ -61,7 +62,7 @@ function parse-command-line command-line-args
       type: 'input'
       name: 'exocom-version'
       message: 'ExoCom version:'
-      default: '0.16.1'
+      default: pkg.version
 
   {data, questions}
 


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves [Originate/exosphere-sdk#232](https://github.com/Originate/exosphere-sdk/issues/232)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->

<!-- tag a few reviewers -->
@kevgo @hugobho 