### PR TITLE
Use serviceType where needed in templates

### DIFF
--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/README.md
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/README.md
@@ -1,2 +1,2 @@
-# _____serviceRole@uppercase_____
+# _____serviceType@uppercase_____
 > _____description_____

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
@@ -1,4 +1,4 @@
-type: _____serviceRole_____
+type: _____serviceType_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-es6/README.md
+++ b/exosphere-shared/templates/add-service/exoservice-es6/README.md
@@ -1,2 +1,2 @@
-# _____serviceRole@uppercase_____ service
+# _____serviceType@uppercase_____ service
 > _____description_____

--- a/exosphere-shared/templates/add-service/exoservice-es6/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6/service.yml
@@ -1,4 +1,4 @@
-type: _____serviceRole_____
+type: _____serviceType_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/README.md
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/README.md
@@ -1,2 +1,2 @@
-# _____serviceRole@uppercase_____
+# _____serviceType@uppercase_____
 > _____description_____

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
@@ -1,4 +1,4 @@
-type: _____serviceRole_____
+type: _____serviceType_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/exoservice-ls/README.md
+++ b/exosphere-shared/templates/add-service/exoservice-ls/README.md
@@ -1,2 +1,2 @@
-# _____serviceRole@uppercase_____ service
+# _____serviceType@uppercase_____ service
 > _____description_____

--- a/exosphere-shared/templates/add-service/exoservice-ls/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls/service.yml
@@ -1,4 +1,4 @@
-type: _____serviceRole_____
+type: _____serviceType_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/service.yml
@@ -1,4 +1,4 @@
-type: _____serviceRole_____
+type: _____serviceType_____
 description: _____description_____
 author: _____author_____
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/service.yml
@@ -1,4 +1,4 @@
-type: _____serviceRole_____
+type: _____serviceType_____
 description: _____description_____
 author: _____author_____
 


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
**Partially** resolves [Originate/exosphere-sdk#223](https://github.com/Originate/exosphere-sdk/issues/223)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Updates the templates to use `serviceType` for the `type` field in `service.yml`

<!-- tag a few reviewers -->
@kevgo @hugobho 