### PR TITLE
exo-create: Allow for creation of reusable services

### DIFF
--- a/exo-create/features/create-service.feature
+++ b/exo-create/features/create-service.feature
@@ -10,7 +10,7 @@ Feature: create a reusable service
 
   Scenario: create reusable service
     Given I am in the root directory of an empty application called "empty app"
-    When executing "exo-create service users-service test-author exoservice-es6-mongodb user manage users"
+    When executing "exo-create service users users-service test-author exoservice-es6-mongodb user manage users"
     Then my application contains the file "application.yml" with the content:
       """
       name: empty app
@@ -23,7 +23,7 @@ Feature: create a reusable service
 
       services:
         public:
-          users-service:
+          users:
             location: ../users-service
       """
     And my workspace contains the file "../users-service/service.yml" with content:

--- a/exo-create/src/cli.ls
+++ b/exo-create/src/cli.ls
@@ -42,7 +42,7 @@ function help
       - options: #{blue "[<app-name>] [<app-version>] [<exocom-version>] [<app-description>]"}
 
     * service       Create a new service for this application located in the parent directory
-      - options: #{blue "[<service-role>] [<author>] [<template-name>] [<model-name>] [<description>]"}
+      - options: #{blue "[<service-role>] [<service-type>] [<author>] [<template-name>] [<model-name>] [<description>]"}
   """
   console.log help-text
 

--- a/exo-create/src/entities/service.ls
+++ b/exo-create/src/entities/service.ls
@@ -20,7 +20,7 @@ service = ->
   inquirer.prompt(questions).then (answers) ->
     data := merge data, answers
     src-path = path.join templates-path, 'add-service', data.template-name
-    target-path = path.join process.cwd!, '..' data.service-role
+    target-path = path.join process.cwd!, '..' data.service-type
     try
       app-config = yaml.safe-load fs.read-file-sync('application.yml', 'utf8')
     catch error
@@ -31,7 +31,7 @@ service = ->
         file: 'application.yml'
         root: 'services.public'
         key: data.service-role
-        value: {location: "../#{data.service-role}"}
+        value: {location: "../#{data.service-type}"}
       yaml-cutter.insert-hash options, N ->
         console.log green "\ndone"
 
@@ -44,15 +44,25 @@ function service-roles
 function parse-command-line command-line-args
   data = {}
   questions = []
-  [_, _, _, service-role, author, template-name, model-name, ...description] = command-line-args
+  [_, _, _, service-role, service-type, author, template-name, model-name, ...description] = command-line-args
 
   if service-role
     data.service-role = service-role
   else
     questions.push do
-      message: 'Name of the service to create'
+      message: 'Role of the service to create'
       type: 'input'
       name: 'serviceRole'
+      filter: (input) -> input.trim!
+      validate: (input) -> input.length > 0
+
+  if service-type
+    data.service-type = service-type
+  else
+    questions.push do
+      message: 'Type of the service to create'
+      type: 'input'
+      name: 'serviceType'
       filter: (input) -> input.trim!
       validate: (input) -> input.length > 0
 
@@ -60,7 +70,7 @@ function parse-command-line command-line-args
     data.template-name = template-name
   else
     questions.push do
-      message: 'Type:'
+      message: 'Template:'
       type: 'list'
       name: 'templateName'
       choices: service-roles!


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
**Partially** resolves [Originate/exosphere-sdk#223](https://github.com/Originate/exosphere-sdk/issues/223)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Updates exo-create to prompt for a `service-type` so that generic/reusable services can be created.

<!-- tag a few reviewers -->
@kevgo @hugobho 