### PR TITLE
exo-add: Allow for creation of reusable services

### DIFF
--- a/exo-add/features/duplicate-role.feature
+++ b/exo-add/features/duplicate-role.feature
@@ -6,7 +6,7 @@ Feature: Attempting to add a duplicate service
 
 
   Scenario: Adding a service-role that already exists
-    Given I am in the directory of an application containing a "users" service
-    When trying to run "exo-add service users test-author exoservice-ls user testing" in this application's directory
+    Given I am in the directory of an application containing a "users" service of type "users-service"
+    When trying to run "exo-add service users users-service test-author exoservice-ls user testing" in this application's directory
     Then it exits with code 1
     And I see the error "Service users already exists in this application"

--- a/exo-add/features/exoservice-es6-mongodb.feature
+++ b/exo-add/features/exoservice-es6-mongodb.feature
@@ -12,7 +12,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
   @verbose
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service user-service test-author exoservice-es6-mongodb user testing" in this application's directory
+    When running "exo-add service users user-service test-author exoservice-es6-mongodb user testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -25,7 +25,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
 
       services:
         public:
-          user-service:
+          users:
             location: ./user-service
       """
     And my application contains the file "user-service/service.yml" with the content:

--- a/exo-add/features/exoservice-es6.feature
+++ b/exo-add/features/exoservice-es6.feature
@@ -11,7 +11,7 @@ Feature: scaffolding an ExoService written in ES6
 
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service users test-author exoservice-es6 user testing" in this application's directory
+    When running "exo-add service users users test-author exoservice-es6 user testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app

--- a/exo-add/features/exoservice-ls-mongodb.feature
+++ b/exo-add/features/exoservice-ls-mongodb.feature
@@ -11,7 +11,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
 
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service user-service test-author exoservice-ls-mongodb user testing" in this application's directory
+    When running "exo-add service users user-service test-author exoservice-ls-mongodb user testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -24,7 +24,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
 
       services:
         public:
-          user-service:
+          users:
             location: ./user-service
       """
     And my application contains the file "user-service/service.yml" with the content:

--- a/exo-add/features/exoservice-ls.feature
+++ b/exo-add/features/exoservice-ls.feature
@@ -11,7 +11,7 @@ Feature: scaffolding an ExoService written in LiveScript
 
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service users test-author exoservice-ls user testing" in this application's directory
+    When running "exo-add service users users test-author exoservice-ls user testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app

--- a/exo-add/features/help.feature
+++ b/exo-add/features/help.feature
@@ -14,5 +14,5 @@ Feature: help command
     Adds a new service to the current application.
     This command must be called in the root directory of the application.
 
-    options: [<service-role>] [<template>] [<model>] [<description>]
+    options: [<service-role>] [<service-type>] [<template>] [<model>] [<description>]
     """

--- a/exo-add/features/htmlserver-express-es6.feature
+++ b/exo-add/features/htmlserver-express-es6.feature
@@ -10,7 +10,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
 
   Scenario: calling with all command line arguments given
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service html-server test-author htmlserver-express-es6 html description" in this application's directory
+    When running "exo-add service web html-server test-author htmlserver-express-es6 html description" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -23,7 +23,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
 
       services:
         public:
-          html-server:
+          web:
             location: ./html-server
       """
     And my application contains the file "html-server/service.yml" with the content:
@@ -55,7 +55,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
 
   Scenario: calling with some command line arguments given
     Given I am in the root directory of an empty application called "test app"
-    When starting "exo-add service html-server test-author htmlserver-express-es6" in this application's directory
+    When starting "exo-add service web html-server test-author htmlserver-express-es6" in this application's directory
     And entering into the wizard:
       | FIELD                  | INPUT                           |
       | Description            | serves HTML UI for the test app |
@@ -73,7 +73,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
 
       services:
         public:
-          html-server:
+          web:
             location: ./html-server
       """
     And my application contains the file "html-server/service.yml" with the content:

--- a/exo-add/features/htmlserver-express-livescript.feature
+++ b/exo-add/features/htmlserver-express-livescript.feature
@@ -10,7 +10,7 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
 
   Scenario: scaffolding a LiveScript HTML server
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service html-server test-author htmlserver-express-livescript html description" in this application's directory
+    When running "exo-add service web html-server test-author htmlserver-express-livescript html description" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -23,7 +23,7 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
 
       services:
         public:
-          html-server:
+          web:
             location: ./html-server
       """
     And my application contains the file "html-server/service.yml" with the content:

--- a/exo-add/features/steps/steps-given.ls
+++ b/exo-add/features/steps/steps-given.ls
@@ -19,12 +19,12 @@ module.exports = ->
     fs.empty-dir-sync @app-dir
 
 
-  @Given /^I am in the directory of an application containing a "([^"]*)" service$/, (service-role, done) !->
+  @Given /^I am in the directory of an application containing a "([^"]*)" service of type "([^"]*)"$/, (service-role, service-type, done) !->
     @app-dir := path.join process.cwd!, 'tmp', 'app'
     @create-empty-app 'app', ~>
       options =
         file: path.join @app-dir, 'application.yml'
         root: 'services.public'
         key: service-role
-        value: {location: "./#{service-role}"}
+        value: {location: "./#{service-type}"}
       yaml-cutter.insert-hash options, done

--- a/exo-add/features/without-arguments.feature
+++ b/exo-add/features/without-arguments.feature
@@ -9,12 +9,13 @@ Feature: interactive scaffolding
     Given I am in the root directory of an empty application called "test app"
     When starting "exo-add service" in this application's directory
     And entering into the wizard:
-      | FIELD                         | INPUT   |
-      | Name of the service to create | web     |
-      | Description                   | testing |
-      | Author                        | tester  |
-      | Type                          |         |
-      | Name of the data model        | web     |
+      | FIELD                         | INPUT       |
+      | Role of the service to create | web         |
+      | Type of the service to create | web         |
+      | Description                   | testing     |
+      | Author                        | tester      |
+      | Template                      |             |
+      | Name of the data model        | web         |
     And waiting until the process ends
     Then my application contains the file "application.yml" with the content:
       """

--- a/exo-add/src/cli.ls
+++ b/exo-add/src/cli.ls
@@ -32,14 +32,14 @@ module.exports = ->
     data := merge data, answers
     check-for-service {existing-services: get-existing-services(app-config.services), service-role: data.service-role}
     src-path = path.join templates-path, 'add-service' data.template-name
-    target-path = path.join process.cwd!, data.service-role
+    target-path = path.join process.cwd!, data.service-type
     data.app-name = app-config.name
     tmplconv.render(src-path, target-path, {data}).then ->
       options =
         file: 'application.yml'
         root: 'services.public'
         key: data.service-role
-        value: {location: "./#{data.service-role}"}
+        value: {location: "./#{data.service-type}"}
       yaml-cutter.insert-hash options, N ->
         console.log green "\ndone"
 
@@ -56,7 +56,7 @@ function help
     Adds a new service to the current application.
     This command must be called in the root directory of the application.
 
-    options: #{blue '[<service-role>] [<template>] [<model>] [<description>]'}
+    options: #{blue '[<service-role>] [<service-type>] [<template>] [<model>] [<description>]'}
     """
   console.log help-message
 
@@ -80,15 +80,25 @@ function get-existing-services services
 function parse-command-line command-line-args
   data = {}
   questions = []
-  [_, _, entity-name, service-role, author, template-name, model-name, description] = command-line-args
+  [_, _, entity-name, service-role, service-type, author, template-name, model-name, description] = command-line-args
 
   if service-role
     data.service-role = service-role
   else
     questions.push do
-      message: 'Name of the service to create:'
+      message: 'Role of the service to create:'
       type: 'input'
       name: 'serviceRole'
+      filter: (input) -> input.trim!
+      validate: (input) -> input.length > 0
+
+  if service-type
+    data.service-type = service-type
+  else
+    questions.push do
+      message: 'Type of the service to create:'
+      type: 'input'
+      name: 'serviceType'
       filter: (input) -> input.trim!
       validate: (input) -> input.length > 0
 
@@ -115,7 +125,7 @@ function parse-command-line command-line-args
     data.template-name = template-name
   else
     questions.push do
-      message: 'Type:'
+      message: 'Template:'
       type: 'list'
       name: 'templateName'
       choices: service-roles!


### PR DESCRIPTION
**Partially** resolves [Originate/exosphere-sdk#223](https://github.com/Originate/exosphere-sdk/issues/223)

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
Prompts the user for a `service-type` field, so that reusable services can be added to the application. 

<!-- tag a few reviewers -->
@kevgo @hugobho 