### PR TITLE
Add exo-deploy spec

### DIFF
--- a/exo-deploy/bin/spec
+++ b/exo-deploy/bin/spec
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "No tests yet"


### PR DESCRIPTION
The publish script runs `spec` for all subdirectories. `exo-deploy` needs a dummy `spec` file for now.

@kevgo @trushton 