### PR TITLE
publish script: push exocom updates

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -41,6 +41,7 @@ function main
   update-exocom-dependencies!
   build-subprojects!
   run-tests!
+  push-exocom-updates!
   bump-version-number!
   push-version-number!
   publish-to-npm!
@@ -58,7 +59,6 @@ function update-exocom-dependencies
   console.log green "Updating ExoCom dependencies...\n"
   update-exocom-package-versions!
   update-exocom-bus-number!
-  run-command "git add -u && git commit -m 'update exocom dependencies' && git push"
   console.log!
 
 
@@ -106,6 +106,12 @@ function build-subprojects
 function run-tests
   console.log green "Running tests in subprojects...\n"
   run-command-in-subdirs './bin/spec'
+  console.log!
+
+
+function push-exocom-updates
+  console.log green "Pushing ExoCom dependency updates...\n"
+  run-command "git add -u && git commit -m 'update exocom dependencies' && git push"
   console.log!
 
 


### PR DESCRIPTION
@kevgo @trushton 

A bug came to me in the middle of the night..
The updated Exocom dependencies should be pushed after tests have run successfully, so that in the event they fail we can discard the changes that were made to update dependencies.