### PR TITLE
exosphere-shared: mongo template bug fix

### DIFF
--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/support/env.js
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/features/support/env.js
@@ -35,8 +35,10 @@ module.exports = function() {
   this.registerHandler('AfterFeatures', (_event, done) => {
     getDb( (db) => {
       db.collection('_____modelName_____s').drop()
-      db.close()
-      done()
+      db.close(function(err, result){
+        if (err) { throw new Error(err) }
+        done()
+      })
     })
   })
 

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/support/env.ls
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/features/support/env.ls
@@ -31,6 +31,6 @@ module.exports = ->
   @registerHandler 'AfterFeatures', (_event, done) ->
     get-db (db) ->
       db.collection('_____modelName_____s')?.drop!
-      db.close!
-      done!
-
+      db.close (err, result) ->
+        | err => throw new Error err
+        done!


### PR DESCRIPTION
Attempting to resolve: https://github.com/Originate/exosphere-sdk/issues/230

My suspicion is that `db.close` isn't finishing before the next steps are run (and it closes the database connection in the next step rather than in the previous one).

@kevgo @trushton 