### PR TITLE
Fix global install

### DIFF
--- a/bin/yarn-install
+++ b/bin/yarn-install
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-ObservableProcess = require('observable-process')
+
+const ObservableProcess = require('observable-process'),
+      async = require('async')
 
 SUBPROJECTS_TO_SETUP = [
   'cli',
@@ -15,11 +17,18 @@ SUBPROJECTS_TO_SETUP = [
   'exosphere-shared'
 ]
 
-for(let project of SUBPROJECTS_TO_SETUP)
-  new ObservableProcess('yarn', { cwd: `./${project}`}).on('ended', function(code) {
-      if(code > 0) {
-        console.log("exosphere-sdk install failed.");
-        process.exit(code);
-      }
+function setupProject(projectName, done) {
+  new ObservableProcess('yarn', { cwd: `./${projectName}`}).on('ended', function(exitCode) {
+    if(exitCode > 0) {
+      console.log("exosphere-sdk install failed.");
+      process.exit(exitCode);
     }
-  )
+    done()
+  })
+}
+
+
+console.log('installing subproject dependencies...')
+async.eachSeries(SUBPROJECTS_TO_SETUP, setupProject, function() {
+  console.log('subproject dependencies installed')
+})

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "exo": "cli/bin/exo"
   },
   "dependencies": {
+    "async": "2.1.4",
     "observable-process": "3.2.2"
   },
   "description": "SDK for the Exosphere framework",
   "devDependencies": {},
   "engines": {
+    "node": ">= 6.0.0",
     "npm": ">= 3.0.0"
   },
   "files": [


### PR DESCRIPTION
The post-install script was running all `yarn` installs in parallel. This was causing random filesystem errors, since Yarn uses a shared cache and isn't thread-safe.

@hugobho @trushton 