### PR TITLE
Fix help command for unknown input

### DIFF
--- a/cli/src/cli.ls
+++ b/cli/src/cli.ls
@@ -92,7 +92,10 @@ function help command
   return missing-command! unless command
   process.argv.push "help"
   process.argv.shift!
-  commands[command]!
+  if commands[command]
+    commands[command]!
+  else
+    unknown-command command
 
 
 function command-names


### PR DESCRIPTION
<!-- a short description of the change in addition to what is already mentioned in the issue above -->I noticed that running `exo help` for an unknown command, such as `exo help status` produced an error due to the `status` command not existing. This PR handles that error correctly

<!-- tag a few reviewers -->
@kevgo 