### PR TITLE
Ignore macOS files in templates

### DIFF
--- a/exo-add/src/cli.ls
+++ b/exo-add/src/cli.ls
@@ -8,7 +8,7 @@ require! {
   'merge'
   'nitroglycerin' : N
   'path'
-  'prelude-ls' : {flatten}
+  'prelude-ls' : {flatten, reject}
   'tmplconv'
   'yaml-cutter'
 }
@@ -46,7 +46,8 @@ module.exports = ->
 
 # Returns the names of all known service templates
 function service-roles
-  fs.readdir-sync path.join(templates-path, 'add-service')
+  fs.readdir-sync path.join(templates-path, 'add-service')  |>  reject (is '.DS_Store')
+
 
 function help
   help-message =


### PR DESCRIPTION
On macOS, it shows `.DS_Store` in the list of templates. This PR fixes that.