### PR TITLE
Pass port mapping to external dependency containers

### DIFF
--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -162,6 +162,7 @@ Feature: Following the tutorial
           docker_flags:
             volume: '-v {{EXO_DATA_PATH}}:/data/db'
             online_text: 'waiting for connections'
+            port: '-p 27017:27017'
       """
     When running "exo setup" in this application's directory
     And running "exo test" in this application's directory

--- a/exo-run/features/run.feature
+++ b/exo-run/features/run.feature
@@ -32,6 +32,13 @@ Feature: running Exosphere applications
     And the "web" service receives a "users.listed" message
 
 
+  Scenario: booting an Exosphere application with external dependencies
+    Given a running "external-dependency" application
+    Then my machine is running the services:
+      | NAME  |
+      | mongo |
+
+
   Scenario: Editing services of an Exosphere application
     Given a running "running" application
     Then my machine is running ExoCom

--- a/exo-run/src/service-runner.ls
+++ b/exo-run/src/service-runner.ls
@@ -76,12 +76,13 @@ class ServiceRunner extends EventEmitter
     dependencies = []
     for dependency-name, dependency-config of @service-config.dependencies or {}
       container-name = "#{@config.app-name}-#{dependency-name}"
-      if dependency-config.docker_flags?
+      if dependency-config?.docker_flags?
         data-path = path.join os.homedir!, '.exosphere', @config.app-name, dependency-name, 'data'
         mkdir '-p', data-path
         volume = Handlebars.compile(that.volume)({"EXO_DATA_PATH": data-path})
         online-text = that.online_text
-      dependencies.push {container-name, dependency-name, volume, online-text}
+        port = that.port
+      dependencies.push {container-name, dependency-name, volume, online-text, port}
     dependencies
 
 

--- a/exo-test/src/service-tester.ls
+++ b/exo-test/src/service-tester.ls
@@ -45,11 +45,11 @@ class ServiceTester extends EventEmitter
   _start-dependencies: (done) ~>
     dependencies = []
     for dependency-name, dependency-config of @service-config.dependencies
-      dependencies.push do
-        container-name: "test-#{dependency-name}"
-        port: '-p 27017:27017'
-        dependency-name: dependency-name
-        online-text: dependency-config.docker_flags?.online_text
+      container-name = "test-#{dependency-name}"
+      if dependency-config?.docker_flags?
+        online-text = that.online_text
+        port = that.port
+      dependencies.push {container-name, dependency-name, online-text, port}
     async.each-series dependencies, DockerHelper.ensure-container-is-running, (err) ~>
       | err  => done err
       done!

--- a/exosphere-shared/example-apps/external-dependency/application.yml
+++ b/exosphere-shared/example-apps/external-dependency/application.yml
@@ -1,0 +1,13 @@
+name: Exosphere-application-with-a-third-party-dependency
+description: For testing booting up dependencies
+author: exospheredev
+version: '1.0'
+
+bus:
+  type: exocom
+  version: 0.21.7
+
+services:
+  public:
+    mongo:
+      location: ./mongo

--- a/exosphere-shared/example-apps/external-dependency/mongo/Dockerfile
+++ b/exosphere-shared/example-apps/external-dependency/mongo/Dockerfile
@@ -1,0 +1,6 @@
+FROM nodesource/node
+
+# These steps ensure that npm install is only run when package.json changes
+COPY ./package.json .
+RUN npm install --production
+COPY . .

--- a/exosphere-shared/example-apps/external-dependency/mongo/package.json
+++ b/exosphere-shared/example-apps/external-dependency/mongo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-mongo-service",
+  "version": "0.0.0",
+  "description": "for testing only, do not publish",
+  "dependencies": {
+    "exoservice": "0.21.7",
+    "mongodb": "2.2.22",
+    "nitroglycerin": "1.1.2"
+  }
+}

--- a/exosphere-shared/example-apps/external-dependency/mongo/server.ls
+++ b/exosphere-shared/example-apps/external-dependency/mongo/server.ls
@@ -11,6 +11,4 @@ module.exports =
       done!
 
 function get-mongo-address
-  if process.env.MONGO
-    return "mongodb://#{process.env.MONGO}"
-  return "mongodb://localhost:27017"
+  return "mongodb://#{process.env.MONGO or 'localhost:27017'}"

--- a/exosphere-shared/example-apps/external-dependency/mongo/server.ls
+++ b/exosphere-shared/example-apps/external-dependency/mongo/server.ls
@@ -1,0 +1,16 @@
+require! {
+  'mongodb' : {MongoClient}
+  'nitroglycerin' : N
+}
+
+module.exports =
+
+  before-all: (done) ->
+    MongoClient.connect get-mongo-address!, N (mongo-db) ->
+      console.log("MongoDB connected")
+      done!
+
+function get-mongo-address
+  if process.env.MONGO
+    return "mongodb://#{process.env.MONGO}"
+  return "mongodb://localhost:27017"

--- a/exosphere-shared/example-apps/external-dependency/mongo/service.yml
+++ b/exosphere-shared/example-apps/external-dependency/mongo/service.yml
@@ -1,0 +1,19 @@
+type: mongo
+description: connects to a local instance of mongo
+author: exospheredev
+
+setup: yarn install
+startup:
+  command: node_modules/exoservice/bin/exo-js
+  online-text: MongoDB connected
+
+dependencies:
+  mongo:
+    docker_flags:
+      volume: '-v {{EXO_DATA_PATH}}:/data/db'
+      online_text: 'waiting for connections'
+      port: '-p 27017:27017'
+
+messages:
+  sends:
+  receives:

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -50,6 +50,7 @@ class DockerHelper
                                     stderr: false)
       ..on 'ended', (exit-code, killed) ~>
         | exit-code > 0 and not killed  =>  
+          # if the image has already been started by another service, use the existing instance
           if /container name ".*" is already in use by container/.test process.full-output!
             return @ensure-container-is-running container, done
           return done "Dependency #{container.container-name} failed to run, shutting down"

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/service.yml
@@ -29,3 +29,4 @@ dependencies:
     docker_flags:
       volume: '-v {{EXO_DATA_PATH}}:/data/db'
       online_text: 'waiting for connections'
+      port: '-p 27017:27017'

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/service.yml
@@ -29,3 +29,4 @@ dependencies:
     docker_flags:
       volume: '-v {{EXO_DATA_PATH}}:/data/db'
       online_text: 'waiting for connections'
+      port: '-p 27017:27017'


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves https://github.com/Originate/exosphere-sdk/issues/252

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
In exosphere-shared/docker-helper.ls:

Also adds a check in `@run-image` to gracefully retry `@ensure-container-is-running` if the process fails with a message indicating that the container is already in use. This is to address an edge case that happens when multiple services use the same dependency and Exosphere tries to boot them up concurrently:
 - `@ensure-container-is-running` first checks if the dependency for `service1` is running. It's not, so it goes to start the container from an image.
- `@ensure-container-is-running` checks if the same dependency for `service2` is running. It's not because Docker is still starting the container from the previous step. It goes to start the same dependency from an image.
- `@run-image` tries to start the dependency for `service2`, but by now the same dependency for `service1` has already been booted up. It errors with a message saying that the container is already in use, which it is.

The logic I put in will re-call `@ensure-container-is-running` with the same container, and this time the method will properly exit after verifying that the dependency has been booted up.

This isn't the cleanest way to handle this problem, but it's the quickest solution for now. We could implement some sort of booting queue, but that would require a larger refactor (which I'm not against)

<!-- tag a few reviewers -->
