### PR TITLE
Fix the tutorial

### DIFF
--- a/cli/features/tutorial.feature
+++ b/cli/features/tutorial.feature
@@ -47,11 +47,14 @@ Feature: Following the tutorial
 
   Scenario: adding the html service
     Given I cd into "todo-app"
-    When starting "exo add service --role=html-server --type=html-server --author=test-author --template=htmlserver-express-es6" in this application's directory
+    When starting "exo add service --template-name=htmlserver-express-es6" in this application's directory
     And entering into the wizard:
-      | FIELD                  | INPUT                           |
-      | Description            | serves HTML UI for the test app |
-      | Name of the data model |                                 |
+      | FIELD                         | INPUT                           |
+      | Role of the service to create | html-server                     |
+      | Type of the service to create | html-server                     |
+      | Description                   | serves HTML UI for the test app |
+      | Author                        | test-author                     |
+      | Name of the data model        |                                 |
     And waiting until the process ends
     Then my application contains the file "application.yml" with the content:
       """
@@ -117,10 +120,14 @@ Feature: Following the tutorial
 
 
   Scenario: adding the todo service
-    When starting "exo add service --role=todo-service --type=todo-service --author=test-author --template=exoservice-es6-mongodb todo --model=todo" in this application's directory
+    When starting "exo add service --template-name=exoservice-es6-mongodb" in this application's directory
     And entering into the wizard:
-      | FIELD       | INPUT                   |
-      | Description | stores the todo entries |
+      | FIELD                         | INPUT                   |
+      | Role of the service to create | todo-service            |
+      | Type of the service to create | todo-service            |
+      | Description                   | stores the todo entries |
+      | Author                        | test-author             |
+      | Name of the data model        | todo                    |
     And waiting until the process ends
     Then my application contains the file "todo-service/service.yml" with the content:
       """

--- a/exo-add/features/duplicate-role.feature
+++ b/exo-add/features/duplicate-role.feature
@@ -7,6 +7,6 @@ Feature: Attempting to add a duplicate service
 
   Scenario: Adding a service-role that already exists
     Given I am in the directory of an application containing a "users" service of type "users-service"
-    When trying to run "exo-add service --role=users --type=users-service --author=test-author --template=exoservice-ls --model=user --description=testing" in this application's directory
+    When trying to run "exo-add service --service-role=users --service-type=users --author=test-author --template-name=exoservice-ls --model=user --description=testing" in this application's directory
     Then it exits with code 1
     And I see the error "Service users already exists in this application"

--- a/exo-add/features/exoservice-es6-mongodb.feature
+++ b/exo-add/features/exoservice-es6-mongodb.feature
@@ -12,7 +12,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
   @verbose
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service --role=users --type=user-service --author=test-author --template=exoservice-es6-mongodb --model=user --description=testing" in this application's directory
+    When running "exo-add service --service-role=user-service --service-type=user-service --author=test-author --template-name=exoservice-es6-mongodb --model=user --description=testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -25,7 +25,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
 
       services:
         public:
-          users:
+          user-service:
             location: ./user-service
       """
     And my application contains the file "user-service/service.yml" with the content:

--- a/exo-add/features/exoservice-es6.feature
+++ b/exo-add/features/exoservice-es6.feature
@@ -11,7 +11,7 @@ Feature: scaffolding an ExoService written in ES6
 
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service --role=users --type=users --author=test-author --template=exoservice-es6 --model=user --description=testing" in this application's directory
+    When running "exo-add service --service-role=users --service-type=users --author=test-author --template-name=exoservice-es6 --model=user --description=testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app

--- a/exo-add/features/exoservice-ls-mongodb.feature
+++ b/exo-add/features/exoservice-ls-mongodb.feature
@@ -11,7 +11,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
 
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service --role=users --type=user-service --author=test-author --template=exoservice-ls-mongodb --model=user --description=testing" in this application's directory
+    When running "exo-add service --service-role=user-service --service-type=user-service --author=test-author --template-name=exoservice-ls-mongodb --model=user --description=testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -24,7 +24,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
 
       services:
         public:
-          users:
+          user-service:
             location: ./user-service
       """
     And my application contains the file "user-service/service.yml" with the content:

--- a/exo-add/features/exoservice-ls.feature
+++ b/exo-add/features/exoservice-ls.feature
@@ -11,7 +11,7 @@ Feature: scaffolding an ExoService written in LiveScript
 
   Scenario: calling with all command line arguments
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service --role=users --type=users --author=test-author --template=exoservice-ls --model=user --description=testing" in this application's directory
+    When running "exo-add service --service-role=users --service-type=users --author=test-author --template-name=exoservice-ls --model=user --description=testing" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app

--- a/exo-add/features/htmlserver-express-es6.feature
+++ b/exo-add/features/htmlserver-express-es6.feature
@@ -10,7 +10,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
 
   Scenario: calling with all command line arguments given
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service --role=web --type=html-server --author=test-author --template=htmlserver-express-es6 --model=html --description=description" in this application's directory
+    When running "exo-add service --service-role=web --service-type=html-server --author=test-author --template-name=htmlserver-express-es6 --model=html --description=description" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app
@@ -67,7 +67,7 @@ Feature: scaffolding an ExpressJS html server written in ES6
 
   Scenario: calling with some command line arguments given
     Given I am in the root directory of an empty application called "test app"
-    When starting "exo-add service --role=web --type=html-server --author=test-author --template=htmlserver-express-es6" in this application's directory
+    When starting "exo-add service --service-role=web --service-type=html-server --author=test-author --template-name=htmlserver-express-es6" in this application's directory
     And entering into the wizard:
       | FIELD                  | INPUT                           |
       | Description            | serves HTML UI for the test app |

--- a/exo-add/features/htmlserver-express-livescript.feature
+++ b/exo-add/features/htmlserver-express-livescript.feature
@@ -10,7 +10,7 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
 
   Scenario: scaffolding a LiveScript HTML server
     Given I am in the root directory of an empty application called "test app"
-    When running "exo-add service --role=web --type=html-server --author=test-author --template=htmlserver-express-livescript --model=html --description=description" in this application's directory
+    When running "exo-add service --service-role=web --service-type=html-server --author=test-author --template-name=htmlserver-express-livescript --model=html --description=description" in this application's directory
     Then my application contains the file "application.yml" with the content:
       """
       name: test app

--- a/exo-add/features/steps/steps-then.ls
+++ b/exo-add/features/steps/steps-then.ls
@@ -11,7 +11,13 @@ module.exports = ->
 
   @Then /^my application contains the file "([^"]*)" with the content:$/, (file-path, expected-content, done) ->
     fs.read-file path.join(@app-dir, file-path), N (actual-content) ->
-      jsdiff-console actual-content.to-string!trim!, expected-content.trim!, done
+      console.log actual-content.to-string!
+      try
+        jsdiff-console actual-content.to-string!trim!, expected-content.trim!
+      catch
+        console.log e
+        done e
+      done!
 
 
   @Then /^my application contains the file "([^"]*)"$/, (file-path) ->

--- a/exo-add/src/cli.ls
+++ b/exo-add/src/cli.ls
@@ -82,11 +82,10 @@ function get-existing-services services
 function parse-command-line command-line-args
   data = {}
   questions = []
-  service-role = command-line-args["role"]
-  entity-name = command-line-args["_"]
-  service-type = command-line-args["type"]
+  service-role = command-line-args["service-role"]
+  service-type = command-line-args["service-type"]
   author = command-line-args["author"]
-  template-name = command-line-args['template']
+  template-name = command-line-args['template-name']
   model-name = command-line-args['model']
   description = command-line-args['description']
 


### PR DESCRIPTION
Makes the tutorial run again. I am switching to longer but more unambiguous command-line parameters for exo-add. I think that's fine since they will only be used in scripts.