### PR TITLE
Fix get-docker-ip function

### DIFF
--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -29,7 +29,8 @@ class DockerHelper
 
 
   @get-docker-ip = (container) ->
-    child_process.exec-sync("docker inspect --format '{{ .NetworkSettings.IPAddress }}' #{container}", "utf8") if DockerHelper.container-exists container
+    if DockerHelper.container-exists container
+      child_process.exec-sync("docker inspect --format '{{ .NetworkSettings.IPAddress }}' #{container}", "utf8") |> (.to-string!) |> (.replace '\n', '') 
 
 
   @get-docker-images = ->


### PR DESCRIPTION
The command returns a buffer that needs to be formatted properly.