### PR TITLE
Fix container-is-running method

### DIFF
--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -11,7 +11,10 @@ class DockerHelper
 
 
   @container-is-running = (container-name) ->
-    child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}') |> (.to-string!) |> (.split '\n') |> (.includes "#{container-name}/Up")
+    running-containers = child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}') |> (.to-string!) |> (.split '\n') 
+    for container in running-containers
+      if container.includes "#{container-name}/Up" then return yes
+    return no
 
 
   @ensure-container-is-running = (container, done) ~>

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -1,6 +1,8 @@
 require! {
   \child_process
+  \prelude-ls : {any}
   \observable-process : ObservableProcess
+  \os
 }
 
 
@@ -11,10 +13,7 @@ class DockerHelper
 
 
   @container-is-running = (container-name) ->
-    running-containers = child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}') |> (.to-string!) |> (.split '\n') 
-    for container in running-containers
-      if container.includes "#{container-name}/Up" then return yes
-    return no
+    child_process.exec-sync('docker ps --format {{.Names}}/{{.Status}}') |> (.to-string!) |> (.split os.EOL) |> any (.includes "#{container-name}/Up")
 
 
   @ensure-container-is-running = (container, done) ~>


### PR DESCRIPTION
When containers have been running for more than a few seconds, their statuses look like so:
```
exocom/Up Less than a second
todo-app-mongo/Up 9 seconds
```
Instead of just `exocom/Up`. We need to check `.includes` against each of the strings in the array rather than the array itself.