### PR TITLE
Print crash report for dependency containers

### DIFF
--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -87,8 +87,9 @@ class DockerHelper
 
   # Prints the last n number of lines from a given text
   @_print-last-lines = (text, number-of-lines) ->
-    split-text = text.split /\r?\n/
-    sliced-text = split-text.slice Math.max(split-text.length - number-of-lines - 1, 0)
-    sliced-text.join (if process.platform == 'win32' then '\r\n' else '\n')
+    text
+      .split \\n
+      .[-number-of-lines to]
+      .join \\n
 
 module.exports = DockerHelper

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -54,6 +54,7 @@ class DockerHelper
           # if the image has already been started by another service, use the existing instance
           if /container name ".*" is already in use by container/.test process.full-output!
             return @ensure-container-is-running container, done
+          console.log @_print-last-lines(process.full-output!, 20)
           return done "Dependency #{container.container-name} failed to run, shutting down"
       ..wait container.online-text, done 
 
@@ -77,5 +78,10 @@ class DockerHelper
       child_process.exec-sync 'docker rm -f $(docker ps -aq)'
 
 
+  # Prints the last n number of lines from a given text
+  @_print-last-lines = (text, number-of-lines) ->
+    split-text = text.split /\r?\n/
+    sliced-text = split-text.slice Math.max(split-text.length - number-of-lines - 1, 0)
+    sliced-text.join (if process.platform == 'win32' then '\r\n' else '\n')
 
 module.exports = DockerHelper


### PR DESCRIPTION
Partly addresses: https://github.com/Originate/exosphere-sdk/issues/261

While not a permanent fix, this change will at least allow the developer not to be completely in the dark when a dependency fails. When we eventually switch to a DockerManger class this might change again. Until that happens we will at least have crash reports for the next release.