### PR TITLE
.dockerignore file in templates

### DIFF
--- a/exo-add/features/exoservice-es6-mongodb.feature
+++ b/exo-add/features/exoservice-es6-mongodb.feature
@@ -70,3 +70,7 @@ Feature: scaffolding an ExoService written in ES6, backed by MongoDB
       # USER-SERVICE
       > testing
       """
+    And my application contains the file "user-service/.dockerignore" containing the text:
+      """
+      node_modules
+      """

--- a/exo-add/features/exoservice-es6.feature
+++ b/exo-add/features/exoservice-es6.feature
@@ -68,3 +68,7 @@ Feature: scaffolding an ExoService written in ES6
       # USERS service
       > testing
       """
+    And my application contains the file "users/.dockerignore" containing the text:
+      """
+      node_modules
+      """

--- a/exo-add/features/exoservice-ls-mongodb.feature
+++ b/exo-add/features/exoservice-ls-mongodb.feature
@@ -69,3 +69,7 @@ Feature: scaffolding an ExoService written in LiveScript, backed by MongoDB
       # USER-SERVICE
       > testing
       """
+    And my application contains the file "user-service/.dockerignore" containing the text:
+      """
+      node_modules
+      """

--- a/exo-add/features/exoservice-ls.feature
+++ b/exo-add/features/exoservice-ls.feature
@@ -65,3 +65,7 @@ Feature: scaffolding an ExoService written in LiveScript
       # USERS service
       > testing
       """
+    And my application contains the file "users/.dockerignore" containing the text:
+      """
+      node_modules
+      """

--- a/exo-add/features/htmlserver-express-es6.feature
+++ b/exo-add/features/htmlserver-express-es6.feature
@@ -63,6 +63,10 @@ Feature: scaffolding an ExpressJS html server written in ES6
       # TEST APP HTML Server
       > description
       """
+    And my application contains the file "html-server/.dockerignore" containing the text:
+      """
+      node_modules
+      """
 
 
   Scenario: calling with some command line arguments given

--- a/exo-add/features/htmlserver-express-livescript.feature
+++ b/exo-add/features/htmlserver-express-livescript.feature
@@ -52,3 +52,7 @@ Feature: scaffolding an ExpressJS HTML service written in LiveScript
       # TEST APP HTML Server
       > description
       """
+    And my application contains the file "html-server/.dockerignore" containing the text:
+      """
+      node_modules
+      """

--- a/exo-add/src/cli.ls
+++ b/exo-add/src/cli.ls
@@ -35,7 +35,8 @@ module.exports = ->
     src-path = path.join templates-path, 'add-service' data.template-name
     target-path = path.join process.cwd!, data.service-type
     data.app-name = app-config.name
-    tmplconv.render(src-path, target-path, {data}).then ->
+    pattern = ['**/*.*', '\.dockerignore']
+    tmplconv.render(src-path, target-path, {data, pattern}).then ->
       options =
         file: 'application.yml'
         root: 'services.public'

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/.dockerignore
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/exosphere-shared/templates/add-service/exoservice-es6-mongodb/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-es6-mongodb/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "exoservice": "0.21.8",
     "get-env": "0.5.10",
-    "mongodb": "2.2.16"
+    "mongodb": "2.2.16",
+    "nitroglycerin": "1.1.2"
   },
   "description": "_____description_____",
   "devDependencies": {
@@ -19,7 +20,6 @@
     "js-yaml": "3.7.0",
     "jsdiff-console": "2.2.1",
     "lowercase-keys": "1.0.0",
-    "nitroglycerin": "1.1.2",
     "o-tools": "0.7.0",
     "port-reservation": "0.3.2",
     "wait": "0.1.0"

--- a/exosphere-shared/templates/add-service/exoservice-es6/.dockerignore
+++ b/exosphere-shared/templates/add-service/exoservice-es6/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/.dockerignore
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/exosphere-shared/templates/add-service/exoservice-ls-mongodb/package.json
+++ b/exosphere-shared/templates/add-service/exoservice-ls-mongodb/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "exoservice": "0.21.8",
     "get-env": "0.5.10",
-    "mongodb": "2.2.16"
+    "mongodb": "2.2.16",
+    "nitroglycerin": "1.1.2"
   },
   "description": "_____description_____",
   "devDependencies": {
@@ -17,7 +18,6 @@
     "js-yaml": "3.7.0",
     "jsdiff-console": "2.2.1",
     "lowercase-keys": "1.0.0",
-    "nitroglycerin": "1.1.2",
     "o-tools": "0.7.0",
     "port-reservation": "0.3.2"
   }

--- a/exosphere-shared/templates/add-service/exoservice-ls/.dockerignore
+++ b/exosphere-shared/templates/add-service/exoservice-ls/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/.dockerignore
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/exosphere-shared/templates/add-service/htmlserver-express-livescript/.dockerignore
+++ b/exosphere-shared/templates/add-service/htmlserver-express-livescript/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
resolves https://github.com/Originate/exosphere-sdk/issues/267

When saving a service, it takes ~10 seconds for the docker image to rebuild, largely from copying over all the stuff from the `node_modules/` directory. 

This PR adds a `.dockerignore` file to the templates so that node modules are not copied over to the docker image, cutting this rebuild time to ~1 second. 

@kevgo @hugobho
