### PR TITLE
Removing mentions of livescript from es6-express template

### DIFF
--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/README.md
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/README.md
@@ -2,7 +2,7 @@
 > _____description_____
 
 This is the HTML server component of the _____appName_____ application.
-It is an [ExpressJS](http://expressjs.com) app written in LiveScript.
+It is an [ExpressJS](http://expressjs.com) app written in JavaScript.
 The server listens on [localhost:3000](http://localhost:3000).
 
 

--- a/exosphere-shared/templates/add-service/htmlserver-express-es6/webpack/webpack-config.js
+++ b/exosphere-shared/templates/add-service/htmlserver-express-es6/webpack/webpack-config.js
@@ -14,15 +14,12 @@ module.exports = {
   },
 
   resolve: {
-    extensions: ['', '.js', '.ls', '.styl']
+    extensions: ['', '.js', '.styl']
   },
 
   module: {
     loaders: [
       {
-        test: /\.ls$/,
-        loader: 'livescript'
-      }, {
         test: /\.styl/,
         loader: 'style!css!stylus'
       }


### PR DESCRIPTION
The es6-express template claims to use livescript in a few places.
resolves https://github.com/Originate/exosphere/issues/220

This PR removes mentions of livescript and changes them to be truthful about using es6 instead!

@hugobho @trushton @kevgo 
