### PR TITLE
dependency-linter ignore tmp dir

### DIFF
--- a/exo-add/dependency-lint.yml
+++ b/exo-add/dependency-lint.yml
@@ -32,6 +32,7 @@ requiredModules:
       - '**/*{.,_,-}{spec,test}.ls'
     ignore:
       - 'node_modules/**/*'
+      - 'tmp/**/*'
     root: '**/*.ls'
   stripLoaders: false
   transpilers:

--- a/exo-clone/dependency-lint.yml
+++ b/exo-clone/dependency-lint.yml
@@ -32,6 +32,7 @@ requiredModules:
       - '**/*{.,_,-}{spec,test}.ls'
     ignore:
       - 'node_modules/**/*'
+      - 'tmp/**/*'
     root: '**/*.ls'
   stripLoaders: false
   transpilers:

--- a/exo-create/dependency-lint.yml
+++ b/exo-create/dependency-lint.yml
@@ -33,6 +33,7 @@ requiredModules:
       - '**/*{.,_,-}{spec,test}.ls'
     ignore:
       - 'node_modules/**/*'
+      - 'tmp/**/*'
     root: '**/*.ls'
   stripLoaders: false
   transpilers:

--- a/exo-deploy/dependency-lint.yml
+++ b/exo-deploy/dependency-lint.yml
@@ -28,6 +28,7 @@ requiredModules:
       - '**/*{.,_,-}{spec,test}.ls'
     ignore:
       - 'node_modules/**/*'
+      - 'tmp/**/*'
     root: '**/*.ls'
   stripLoaders: false
   transpilers:

--- a/exo-lint/dependency-lint.yml
+++ b/exo-lint/dependency-lint.yml
@@ -32,6 +32,7 @@ requiredModules:
       - '**/*{.,_,-}{spec,test}.ls'
     ignore:
       - 'node_modules/**/*'
+      - 'tmp/**/*'
     root: '**/*.ls'
   stripLoaders: false
   transpilers:

--- a/exo-test/dependency-lint.yml
+++ b/exo-test/dependency-lint.yml
@@ -33,6 +33,7 @@ requiredModules:
       - '**/*{.,_,-}{spec,test}.ls'
     ignore:
       - 'node_modules/**/*'
+      - 'tmp/**/*'
     root: '**/*.ls'
   stripLoaders: false
   transpilers:


### PR DESCRIPTION
Linter will fail sometimes because it tries to lint the packages listed under test apps in the `tmp` dir. This ignore statement was previously added to some but not all of the subdirs.