### PR TITLE
Cleanup exo-clean tests

### DIFF
--- a/exo-clean/features/clean.feature
+++ b/exo-clean/features/clean.feature
@@ -12,14 +12,9 @@ Feature: cleaning dangling Docker images
 
     Scenario: cleaning a machine with both dangling and non-dangling Doker images
     Given my machine has both dangling and non-dangling Docker images and volumes
-    And it has the Docker images:
-      | tmp_mongo |
-      | <none>    |
     When running "exo-clean" in the terminal
     Then it prints "removed all dangling images" in the terminal
     And it prints "removed all dangling volumes" in the terminal
-    And it has the Docker images:
-      | tmp_mongo |
-    And it does not have the Docker images:
-      | <none>    |
+    And it has non-dangling images
+    And it does not have dangling images
     And it does not have dangling volumes

--- a/exo-clean/features/steps/steps-then.ls
+++ b/exo-clean/features/steps/steps-then.ls
@@ -15,19 +15,16 @@ defineSupportCode ({Then}) ->
     @process.wait expected-text, done
 
 
-  Then /^it has the Docker images:$/ (table, done) ->
+  Then /^it has non-dangling images$/ (done) ->
     DockerHelper.list-images (err, docker-images) ->
-      for row in table.raw!
-        expect(docker-images).to.include row[0]
+      expect(docker-images.length).to.be.greater-than 0
       done!
 
 
-  Then /^it does not have the Docker images:$/ (table, done) ->
-    DockerHelper.list-images (err, docker-images) ->
-      for row in table.raw!
-        expect(docker-images).to.not.include row[0]
+  Then /^it does not have dangling images/ (done) ->
+    DockerHelper.get-dangling-images (err, images) ->
+      expect(images.length).to.equal 0
       done!
-
 
   Then /^it does not have dangling volumes$/ (done) ->
     DockerHelper.get-dangling-volumes (err, volumes) ->

--- a/exo-clean/features/steps/steps-then.ls
+++ b/exo-clean/features/steps/steps-then.ls
@@ -27,6 +27,7 @@ defineSupportCode ({Then}) ->
       expect(images.length).to.equal 0
       done!
 
+
   Then /^it does not have dangling volumes$/ (done) ->
     DockerHelper.get-dangling-volumes (err, volumes) ->
       expect(volumes.length).to.equal 0

--- a/exo-clean/features/steps/steps-then.ls
+++ b/exo-clean/features/steps/steps-then.ls
@@ -16,9 +16,10 @@ defineSupportCode ({Then}) ->
 
 
   Then /^it has non-dangling images$/ (done) ->
-    DockerHelper.list-images (err, docker-images) ->
-      expect(docker-images.length).to.be.greater-than 0
-      done!
+    DockerHelper.list-images (err, all-images) ->
+      DockerHelper.get-dangling-images (err, dangling-images) ->
+        expect(all-images.length).to.be.greater-than dangling-images.length 
+        done!
 
 
   Then /^it does not have dangling images/ (done) ->


### PR DESCRIPTION
Turns out an image named `<none>:<none>` doesn't necessarily mean it's dangling: http://www.projectatomic.io/blog/2015/07/what-are-docker-none-none-images/

This PR makes things simpler just by calling the dedicated `@get-dangling-images` method to check for dangling images. It also removes the second step definition `And it has the Docker images` because that's implicit within the first `Given`