### PR TITLE
cleanup: remove ignoring scenarios tagged with todo

### DIFF
--- a/cli/bin/spec_ci
+++ b/cli/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-NODE_ENV='test' node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+NODE_ENV='test' node_modules/.bin/cucumber-js --format pretty

--- a/exo-add/bin/spec_ci
+++ b/exo-add/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-clean/bin/spec_ci
+++ b/exo-clean/bin/spec_ci
@@ -3,5 +3,5 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-(cd ../exo-setup && bin/setup)
+(cd ../exo-setup && bin/setup && node_modules/.bin/build)
 node_modules/.bin/cucumber-js --format pretty

--- a/exo-clean/bin/spec_ci
+++ b/exo-clean/bin/spec_ci
@@ -3,5 +3,5 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-(cd ../exo-setup && bin/setup && node_modules/.bin/build)
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+(cd ../exo-setup && bin/setup)
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-clone/bin/spec_ci
+++ b/exo-clone/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-create/bin/spec_ci
+++ b/exo-create/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-lint/bin/spec_ci
+++ b/exo-lint/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-run/bin/spec_ci
+++ b/exo-run/bin/spec_ci
@@ -4,4 +4,4 @@ set -e
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
 (cd ../exo-setup && bin/setup && node_modules/.bin/build)
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-setup/bin/spec_ci
+++ b/exo-setup/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-setup/yarn.lock
+++ b/exo-setup/yarn.lock
@@ -291,7 +291,7 @@ dependency-lint@4.3.1:
     semver "^5.1.0"
     sorted-object "^2.0.0"
 
-dependency-lint@^5.0.1:
+dependency-lint@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dependency-lint/-/dependency-lint-5.0.1.tgz#2ef759a87bd5608b6bdd2af772c9d6a15b1e89ab"
   dependencies:

--- a/exo-setup/yarn.lock
+++ b/exo-setup/yarn.lock
@@ -291,7 +291,7 @@ dependency-lint@4.3.1:
     semver "^5.1.0"
     sorted-object "^2.0.0"
 
-dependency-lint@5.0.1:
+dependency-lint@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dependency-lint/-/dependency-lint-5.0.1.tgz#2ef759a87bd5608b6bdd2af772c9d6a15b1e89ab"
   dependencies:

--- a/exo-sync/bin/spec_ci
+++ b/exo-sync/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty

--- a/exo-test/bin/spec_ci
+++ b/exo-test/bin/spec_ci
@@ -3,4 +3,4 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 node_modules/.bin/dependency-lint
-node_modules/.bin/cucumber-js --tags ~@todo --format pretty
+node_modules/.bin/cucumber-js --format pretty


### PR DESCRIPTION
There are no scenarios tagged with todo and this was causing the exo-clean and exo-run tests to not run on ci (because cucumber-js tag interface changed from 1.0 to 2.0).

Couldn't easily see that no tests were running because of the huge amount of output. I'm working on reducing the output on CI now. 
