### PR TITLE
exo-clean: fix tests

### DIFF
--- a/exo-clean/src/cli.ls
+++ b/exo-clean/src/cli.ls
@@ -11,10 +11,14 @@ module.exports = ->
   console.log 'We are about to clean up your Docker workspace!\n'
 
   DockerHelper.get-dangling-images (err, images) ->
-    DockerHelper.force-remove-images images, ->
+    | err => throw err
+    DockerHelper.force-remove-images images, (err) ->
+      | err => throw err
       console.log green 'removed all dangling images'
   DockerHelper.get-dangling-volumes (err, volumes) ->
-    DockerHelper.force-remove-volumes volumes, ->
+    | err => throw err
+    DockerHelper.force-remove-volumes volumes, (err) ->
+      | err => throw err
       console.log green 'removed all dangling volumes'
 
 

--- a/exosphere-shared/src/docker-helper.ls
+++ b/exosphere-shared/src/docker-helper.ls
@@ -100,7 +100,7 @@ class DockerHelper
 
 
   @force-remove-images = (images, done) ->
-    async.map-series images, (-> docker.get-volume(&0.Id).remove {force:true}, &1), done
+    async.map-series images, (-> docker.get-image(&0.Id).remove {force:true}, &1), done
 
 
   @get-dangling-volumes = (done) ->


### PR DESCRIPTION
broke in https://github.com/Originate/exosphere/commit/60a0c1ef099fc9ceb7dec69afed351692e9fb701 but we weren't aware since the exo-clean tests weren't running on ci (which was broken in a separate PR)