### PR TITLE
Update nats bus config

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -101,7 +101,7 @@ function update-exocom-dependency-number
         $1version: #{@target-version}
         """
     replace.sync do
-      files: ['**/features/**/*.ls']
+      files: ['**/features/**/*.ls', '**/*.feature']
       replace: /exocom\d+.\d+.\d+/g
       with: "exocom#{@target-version}"
     replace.sync do

--- a/exo-run/features/app-dependency.feature
+++ b/exo-run/features/app-dependency.feature
@@ -1,0 +1,23 @@
+Feature: running Exosphere applications with dependencies
+
+  As an Exosphere developer
+  I want to have an easy way to run application wide dependencies
+  So that all my services can use these dependencies.
+
+  Rules:
+  - run "exo run" in the directory of your application to run it
+  - this command boots up all the dependencies of the application
+
+
+  Scenario: booting an Exosphere application with Exocom as a listed dependency
+    Given a running "simple" application
+    Then my machine is running the services:
+      | NAME         |
+      | exocom0.22.0 |
+
+
+  Scenario: booting an Exosphere application with Nats as a listed dependency
+    Given a running "nats" application
+    Then my machine is running the services:
+      | NAME      |
+      | nats0.9.6 |

--- a/exo-run/src/app-runner.ls
+++ b/exo-run/src/app-runner.ls
@@ -29,11 +29,11 @@ class AppRunner extends EventEmitter
     online-texts = @_compile-online-text!
     asynchronizer = new Asynchronizer Object.keys(online-texts)
 
-    for role, online-text of online-texts 
+    for role, online-text of online-texts
       let role, online-text
         @process.wait (new RegExp(role + ".*" + online-text)), ~>
           @logger.log {role, text: "'#{role}' is running"}
-          asynchronizer.check role  
+          asynchronizer.check role
 
     asynchronizer.then ~>
       @write 'all services online'
@@ -58,6 +58,9 @@ class AppRunner extends EventEmitter
 
   _compile-online-text: ->
     online-texts = {}
+    for app-dependency in @app-config.dependencies
+      dependency = ApplicationDependency.build app-dependency
+      online-texts[app-dependency.type] = dependency.get-online-text!
     for protection-level of @app-config.services
       for role, service-data of @app-config.services[protection-level]
         if service-data.location #TODO: compile online text for external services

--- a/exosphere-shared/example-apps/nats/application.yml
+++ b/exosphere-shared/example-apps/nats/application.yml
@@ -1,0 +1,10 @@
+name: empty Exosphere application
+description: used to test nats dependency
+author: exospheredev
+version: '1.0'
+
+dependencies:
+  - type: nats
+    version: 0.9.6
+
+services:

--- a/exosphere-shared/src/application-dependency/exocom.ls
+++ b/exosphere-shared/src/application-dependency/exocom.ls
@@ -30,6 +30,10 @@ class ExocomDependency
             SERVICE_ROUTES: JSON.stringify service-routes
 
 
+  get-online-text: ->
+    'ExoCom WebSocket listener online'
+
+
   _get-container-name: ->
     "exocom#{@version}"
 

--- a/exosphere-shared/src/application-dependency/nats.ls
+++ b/exosphere-shared/src/application-dependency/nats.ls
@@ -8,10 +8,11 @@ class NatsDependency
   get-service-env-variables: ->
     NATS_HOST: @_get-container-name!
 
-  get-docker-config: (app-config) ->
-    "#{@_get-container-name!}":
-      image: "nats:#{@version}"
-      container_name: @_get-container-name!
+  get-docker-config: (app-config, done) ->
+    done null, do
+      "#{@_get-container-name!}":
+        image: "nats:#{@version}"
+        container_name: @_get-container-name!
 
   _get-container-name: ->
     "nats#{@version}"

--- a/exosphere-shared/src/application-dependency/nats.ls
+++ b/exosphere-shared/src/application-dependency/nats.ls
@@ -5,14 +5,21 @@ class NatsDependency
   get-env-variables: ->
     {}
 
+
   get-service-env-variables: ->
     NATS_HOST: @_get-container-name!
+
 
   get-docker-config: (app-config, done) ->
     done null, do
       "#{@_get-container-name!}":
         image: "nats:#{@version}"
         container_name: @_get-container-name!
+
+
+  get-online-text: ->
+    'Listening for route connections'
+
 
   _get-container-name: ->
     "nats#{@version}"


### PR DESCRIPTION
`get-docker-config` uses callbacks now, forgot to update this method when Exocom's driver was switched.