### PR TITLE
cleanup: remove use of cucumber-js '--strict'

### DIFF
--- a/cli/bin/features
+++ b/cli/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/cli/bin/features.cmd
+++ b/cli/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/cli/bin/spec
+++ b/cli/bin/spec
@@ -5,7 +5,7 @@ node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   # NOTE (KG): this is broken for the time being
   # node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/cli/bin/spec.cmd
+++ b/cli/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-add/bin/features
+++ b/exo-add/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-add/bin/features.cmd
+++ b/exo-add/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-add/bin/spec
+++ b/exo-add/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-add/bin/spec.cmd
+++ b/exo-add/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-clean/bin/features
+++ b/exo-clean/bin/features
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 (cd ../exo-setup && bin/setup && node_modules/.bin/build)
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-clean/bin/spec
+++ b/exo-clean/bin/spec
@@ -7,5 +7,5 @@ if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
   cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-clone/bin/features
+++ b/exo-clone/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-clone/bin/features.cmd
+++ b/exo-clone/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-clone/bin/spec
+++ b/exo-clone/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-clone/bin/spec.cmd
+++ b/exo-clone/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-create/bin/features
+++ b/exo-create/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-create/bin/features.cmd
+++ b/exo-create/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-create/bin/spec
+++ b/exo-create/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-create/bin/spec.cmd
+++ b/exo-create/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-lint/bin/features
+++ b/exo-lint/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-lint/bin/features.cmd
+++ b/exo-lint/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-lint/bin/spec
+++ b/exo-lint/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-lint/bin/spec.cmd
+++ b/exo-lint/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-run/bin/features
+++ b/exo-run/bin/features
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 (cd ../exo-setup && bin/setup && node_modules/.bin/build)
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-run/bin/features.cmd
+++ b/exo-run/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-call node_modules\.bin\cucumber-js --strict %*
+call node_modules\.bin\cucumber-js %*

--- a/exo-run/bin/spec
+++ b/exo-run/bin/spec
@@ -7,5 +7,5 @@ if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
   cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-run/bin/spec.cmd
+++ b/exo-run/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-call node_modules\.bin\cucumber-js --strict %*
+call node_modules\.bin\cucumber-js %*

--- a/exo-setup/bin/features
+++ b/exo-setup/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  node_modules/.bin/cucumber-js --strict
+  node_modules/.bin/cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' node_modules/.bin/cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' node_modules/.bin/cucumber-js "$@"
 fi

--- a/exo-setup/bin/features.cmd
+++ b/exo-setup/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-setup/bin/spec
+++ b/exo-setup/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  node_modules/.bin/cucumber-js --strict
+  node_modules/.bin/cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' node_modules/.bin/cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' node_modules/.bin/cucumber-js "$@"
 fi

--- a/exo-setup/bin/spec.cmd
+++ b/exo-setup/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-sync/bin/features
+++ b/exo-sync/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-sync/bin/features.cmd
+++ b/exo-sync/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-sync/bin/spec
+++ b/exo-sync/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-sync/bin/spec.cmd
+++ b/exo-sync/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-test/bin/features
+++ b/exo-test/bin/features
@@ -3,7 +3,7 @@ set -e
 
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-test/bin/features.cmd
+++ b/exo-test/bin/features.cmd
@@ -1,2 +1,2 @@
 call node_modules\o-tools-livescript\bin\build
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*

--- a/exo-test/bin/spec
+++ b/exo-test/bin/spec
@@ -4,7 +4,7 @@ set -e
 node_modules/o-tools-livescript/bin/build
 if [ "$#" == "0" ]; then
   node_modules/.bin/dependency-lint
-  cucumber-js --strict
+  cucumber-js
 else
-  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js --strict "$@"
+  DEBUG='*,-express:*,-body-parser:*,-observable-process,-text-stream-search,-rails-delegate,-exorelay:*,-stylus:*' cucumber-js "$@"
 fi

--- a/exo-test/bin/spec.cmd
+++ b/exo-test/bin/spec.cmd
@@ -1,3 +1,3 @@
 call node_modules\o-tools-livescript\bin\build
 call node_modules\o-tools\bin\lint
-node_modules\.bin\cucumber-js --strict %*
+node_modules\.bin\cucumber-js %*


### PR DESCRIPTION
After updating to cucumber 2.0, this option is no longer valid.

I mentioned this in #280 but my comment was missed.