### PR TITLE
wait for expected text in exo-add tests

### DIFF
--- a/exo-create/main_test.go
+++ b/exo-create/main_test.go
@@ -40,7 +40,7 @@ func run(command []string) error {
 
 func enterInput(row *gherkin.TableRow) error {
 	field, input := row.Cells[0].Value, row.Cells[1].Value
-	if err = testHelpers.WaitForText(out, field, 1000); err != nil {
+	if err = testHelpers.WaitForText(&out, field, 1000); err != nil {
 		return err
 	}
 	_, err := in.Write([]byte(input + "\n"))
@@ -77,11 +77,11 @@ func FeatureContext(s *godog.Suite) {
 	})
 
 	s.Step(`^waiting until I see "([^"]*)" in the terminal$`, func(expectedText string) error {
-		return testHelpers.WaitForText(out, expectedText, 1000)
+		return testHelpers.WaitForText(&out, expectedText, 1000)
 	})
 
 	s.Step(`^it prints "([^"]*)" in the terminal$`, func(expectedText string) error {
-		return testHelpers.WaitForText(out, expectedText, 1000)
+		return testHelpers.WaitForText(&out, expectedText, 1000)
 	})
 
 	s.Step(`^my workspace contains the file "([^"]*)" with content:$`, func(fileName string, expectedContent *gherkin.DocString) error {

--- a/exo-create/test_helpers/test_helpers.go
+++ b/exo-create/test_helpers/test_helpers.go
@@ -37,13 +37,14 @@ func ValidateTextContains(haystack, needle string) error {
 	return fmt.Errorf(validateTextContainsErrorTemplate, haystack, needle)
 }
 
-func WaitForText(stdout bytes.Buffer, text string, duration int) error {
+func WaitForText(stdout *bytes.Buffer, text string, duration int) error {
 	interval := time.Tick(100 * time.Millisecond)
 	timeout := time.After(time.Duration(duration) * time.Millisecond)
-	for !strings.Contains(stdout.String(), text) {
+	var output string
+	for !strings.Contains(output, text) {
 		select {
 		case <-interval:
-			return nil
+			output = stdout.String()
 		case <-timeout:
 			return fmt.Errorf("Timed out after %s milliseconds", duration)
 		}


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->


<!-- a short description of the change in addition to what is already mentioned in the issue above -->
The original implementation never waits for the expected text, it always stops waiting after the first tick. It just happens to work because one tick time turns out to be enough. I had the correct implementation at some point and somehow it got replaced by this. 
<!-- tag a few reviewers -->
