### PR TITLE
fix the way exo-deploy calls appConfigHelpers

### DIFF
--- a/exo-go/src/cmd/deploy.go
+++ b/exo-go/src/cmd/deploy.go
@@ -20,8 +20,11 @@ var deployCmd = &cobra.Command{
 			return
 		}
 		fmt.Println("We are about to deploy an application!")
-
-		appConfig, err := appConfigHelpers.GetAppConfig()
+		appDir, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		appConfig, err := appConfigHelpers.GetAppConfig(appDir)
 		if err != nil {
 			log.Fatalf("Cannot read application configuration: %s", err)
 		}


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->

<!-- a short description of the change in addition to what is already mentioned in the issue above -->
The tests failed because we didn't pass in `appDir` when calling `appConfigHelpers.GetAppConfig`. 

<!-- tag a few reviewers -->
