### PR TITLE
simplify struct methods

### DIFF
--- a/exo-go/src/app_dependency_helpers/exocom.go
+++ b/exo-go/src/app_dependency_helpers/exocom.go
@@ -15,13 +15,13 @@ type exocomDependency struct {
 	appDir    string
 }
 
-func (exocom exocomDependency) compileServiceRoutes() ([]map[string]interface{}, error) {
+func (e *exocomDependency) compileServiceRoutes() ([]map[string]interface{}, error) {
 	routes := []map[string]interface{}{}
-	serviceConfigs, err := serviceConfigHelpers.GetServiceConfigs(exocom.appDir, exocom.appConfig)
+	serviceConfigs, err := serviceConfigHelpers.GetServiceConfigs(e.appDir, e.appConfig)
 	if err != nil {
 		return routes, err
 	}
-	serviceData := serviceConfigHelpers.GetServiceData(exocom.appConfig.Services)
+	serviceData := serviceConfigHelpers.GetServiceData(e.appConfig.Services)
 	for serviceName, serviceConfig := range serviceConfigs {
 		route := map[string]interface{}{
 			"role":     serviceName,
@@ -38,15 +38,15 @@ func (exocom exocomDependency) compileServiceRoutes() ([]map[string]interface{},
 }
 
 // GetContainerName returns the container name
-func (exocom exocomDependency) GetContainerName() string {
-	return exocom.config.Name + exocom.config.Version
+func (e *exocomDependency) GetContainerName() string {
+	return e.config.Name + e.config.Version
 }
 
 // GetDeploymentConfig returns Exocom configuration needed in deployment
-func (exocom exocomDependency) GetDeploymentConfig() map[string]string {
+func (e *exocomDependency) GetDeploymentConfig() map[string]string {
 	config := map[string]string{
-		"version": exocom.config.Version,
-		"dnsName": exocom.appConfig.Production["url"],
+		"version": e.config.Version,
+		"dnsName": e.appConfig.Production["url"],
 		//"serviceRoutes":, TODO: wait for exo setup implementation
 		//"dockerImage":, TODO: wait for ecr implementation
 	}
@@ -54,8 +54,8 @@ func (exocom exocomDependency) GetDeploymentConfig() map[string]string {
 }
 
 // GetDockerConfig returns docker configuration and an error if any
-func (exocom exocomDependency) GetDockerConfig() (types.DockerConfig, error) {
-	serviceRoutes, err := exocom.compileServiceRoutes()
+func (e *exocomDependency) GetDockerConfig() (types.DockerConfig, error) {
+	serviceRoutes, err := e.compileServiceRoutes()
 	if err != nil {
 		return types.DockerConfig{}, err
 	}
@@ -64,8 +64,8 @@ func (exocom exocomDependency) GetDockerConfig() (types.DockerConfig, error) {
 		return types.DockerConfig{}, err
 	}
 	return types.DockerConfig{
-		ContainerName: exocom.GetContainerName(),
-		Image:         fmt.Sprintf("originate/exocom:%s", exocom.config.Version),
+		ContainerName: e.GetContainerName(),
+		Image:         fmt.Sprintf("originate/exocom:%s", e.config.Version),
 		Command:       "bin/exocom",
 		Environment: map[string]string{
 			"ROLE":           "exocom",
@@ -76,7 +76,7 @@ func (exocom exocomDependency) GetDockerConfig() (types.DockerConfig, error) {
 }
 
 // GetEnvVariables returns the environment variables
-func (exocom exocomDependency) GetEnvVariables() map[string]string {
+func (e *exocomDependency) GetEnvVariables() map[string]string {
 	port := os.Getenv("EXOCOM_PORT")
 	if len(port) == 0 {
 		port = "80"
@@ -85,15 +85,15 @@ func (exocom exocomDependency) GetEnvVariables() map[string]string {
 }
 
 // GetOnlineText returns the online text for the exocom
-func (exocom exocomDependency) GetOnlineText() string {
+func (e *exocomDependency) GetOnlineText() string {
 	return "ExoCom WebSocket listener online"
 }
 
 // GetServiceEnvVariables returns the environment variables that need to
 // be passed to services that use it
-func (exocom exocomDependency) GetServiceEnvVariables() map[string]string {
+func (e *exocomDependency) GetServiceEnvVariables() map[string]string {
 	return map[string]string{
-		"EXOCOM_HOST": exocom.GetContainerName(),
+		"EXOCOM_HOST": e.GetContainerName(),
 		"EXOCOM_PORT": "$EXOCOM_PORT",
 	}
 }

--- a/exo-go/src/app_dependency_helpers/generic.go
+++ b/exo-go/src/app_dependency_helpers/generic.go
@@ -15,44 +15,44 @@ type genericDependency struct {
 }
 
 // GetContainerName returns the container name
-func (dependency genericDependency) GetContainerName() string {
-	return dependency.config.Name + dependency.config.Version
+func (g *genericDependency) GetContainerName() string {
+	return g.config.Name + g.config.Version
 }
 
 //GetDeploymentConfig returns configuration needed in deployment
-func (dependency genericDependency) GetDeploymentConfig() map[string]string {
+func (g *genericDependency) GetDeploymentConfig() map[string]string {
 	config := map[string]string{
-		"version": dependency.config.Version,
+		"version": g.config.Version,
 	}
 	return config
 }
 
 // GetDockerConfig returns docker configuration and an error if any
-func (dependency genericDependency) GetDockerConfig() (types.DockerConfig, error) {
-	renderedVolumes, err := dockerHelpers.GetRenderedVolumes(dependency.config.Config.Volumes, dependency.appConfig.Name, dependency.config.Name, dependency.homeDir)
+func (g *genericDependency) GetDockerConfig() (types.DockerConfig, error) {
+	renderedVolumes, err := dockerHelpers.GetRenderedVolumes(g.config.Config.Volumes, g.appConfig.Name, g.config.Name, g.homeDir)
 	if err != nil {
 		return types.DockerConfig{}, err
 	}
 	return types.DockerConfig{
-		Image:         fmt.Sprintf("%s:%s", dependency.config.Name, dependency.config.Version),
-		ContainerName: dependency.GetContainerName(),
-		Ports:         dependency.config.Config.Ports,
+		Image:         fmt.Sprintf("%s:%s", g.config.Name, g.config.Version),
+		ContainerName: g.GetContainerName(),
+		Ports:         g.config.Config.Ports,
 		Volumes:       renderedVolumes,
 	}, nil
 }
 
 // GetEnvVariables returns the environment variables
-func (dependency genericDependency) GetEnvVariables() map[string]string {
-	return dependency.config.Config.DependencyEnvironment
+func (g *genericDependency) GetEnvVariables() map[string]string {
+	return g.config.Config.DependencyEnvironment
 }
 
 // GetOnlineText returns the online text
-func (dependency genericDependency) GetOnlineText() string {
-	return dependency.config.Config.OnlineText
+func (g *genericDependency) GetOnlineText() string {
+	return g.config.Config.OnlineText
 }
 
 // GetServiceEnvVariables returns the environment variables that need to
 // be passed to services that use it
-func (dependency genericDependency) GetServiceEnvVariables() map[string]string {
-	return dependency.config.Config.ServiceEnvironment
+func (g *genericDependency) GetServiceEnvVariables() map[string]string {
+	return g.config.Config.ServiceEnvironment
 }

--- a/exo-go/src/app_dependency_helpers/index.go
+++ b/exo-go/src/app_dependency_helpers/index.go
@@ -18,10 +18,10 @@ type AppDependency interface {
 func Build(dependency types.Dependency, appConfig types.AppConfig, appDir, homeDir string) AppDependency {
 	switch dependency.Name {
 	case "exocom":
-		return exocomDependency{dependency, appConfig, appDir}
+		return &exocomDependency{dependency, appConfig, appDir}
 	case "nats":
-		return natsDependency{dependency, appConfig, appDir}
+		return &natsDependency{dependency, appConfig, appDir}
 	default:
-		return genericDependency{dependency, appConfig, appDir, homeDir}
+		return &genericDependency{dependency, appConfig, appDir, homeDir}
 	}
 }

--- a/exo-go/src/app_dependency_helpers/nats.go
+++ b/exo-go/src/app_dependency_helpers/nats.go
@@ -13,38 +13,38 @@ type natsDependency struct {
 }
 
 // GetContainerName returns the container name
-func (nats natsDependency) GetContainerName() string {
-	return nats.config.Name + nats.config.Version
+func (n *natsDependency) GetContainerName() string {
+	return n.config.Name + n.config.Version
 }
 
 //GetDeploymentConfig returns configuration needed in deployment
-func (nats natsDependency) GetDeploymentConfig() map[string]string {
+func (n *natsDependency) GetDeploymentConfig() map[string]string {
 	config := map[string]string{
-		"version": nats.config.Version,
+		"version": n.config.Version,
 	}
 	return config
 }
 
 // GetDockerConfig returns docker configuration and an error if any
-func (nats natsDependency) GetDockerConfig() (types.DockerConfig, error) {
+func (n *natsDependency) GetDockerConfig() (types.DockerConfig, error) {
 	return types.DockerConfig{
-		Image:         fmt.Sprintf("nats:%s", nats.config.Version),
-		ContainerName: nats.GetContainerName(),
+		Image:         fmt.Sprintf("nats:%s", n.config.Version),
+		ContainerName: n.GetContainerName(),
 	}, nil
 }
 
 // GetEnvVariables returns the environment variables
-func (nats natsDependency) GetEnvVariables() map[string]string {
+func (n *natsDependency) GetEnvVariables() map[string]string {
 	return map[string]string{}
 }
 
 // GetOnlineText returns the online text for the nats
-func (nats natsDependency) GetOnlineText() string {
+func (n *natsDependency) GetOnlineText() string {
 	return "Listening for route connections"
 }
 
 // GetServiceEnvVariables returns the environment variables that need to
 // be passed to services that use it
-func (nats natsDependency) GetServiceEnvVariables() map[string]string {
-	return map[string]string{"NATS_HOST": nats.GetContainerName()}
+func (n *natsDependency) GetServiceEnvVariables() map[string]string {
+	return map[string]string{"NATS_HOST": n.GetContainerName()}
 }

--- a/exo-go/src/logger/index.go
+++ b/exo-go/src/logger/index.go
@@ -25,54 +25,54 @@ func NewLogger(roles, silencedRoles []string) *Logger {
 	return logger
 }
 
-func (logger *Logger) getColor(role string) (color.Attribute, bool) {
-	printColor, exist := logger.Colors[role]
+func (l *Logger) getColor(role string) (color.Attribute, bool) {
+	printColor, exist := l.Colors[role]
 	return printColor, exist
 }
 
-func (logger *Logger) getDefaultColors() []color.Attribute {
+func (l *Logger) getDefaultColors() []color.Attribute {
 	return []color.Attribute{color.FgMagenta, color.FgBlue, color.FgYellow, color.FgCyan, color.FgGreen, color.FgWhite}
 }
 
 // Log logs the given text
-func (logger *Logger) Log(role, text string, trim bool) {
+func (l *Logger) Log(role, text string, trim bool) {
 	if trim {
 		text = strings.TrimSpace(text)
 	}
 	for _, line := range strings.Split(text, `\n`) {
 		serviceName, serviceOutput := util.ParseDockerComposeLog(role, line)
-		if !util.DoesStringArrayContain(logger.SilencedRoles, serviceName) {
-			logger.logOutput(serviceName, serviceOutput)
+		if !util.DoesStringArrayContain(l.SilencedRoles, serviceName) {
+			l.logOutput(serviceName, serviceOutput)
 		}
 	}
 }
 
-func (logger *Logger) logOutput(serviceName, serviceOutput string) {
-	if printColor, exists := logger.getColor(serviceName); exists {
+func (l *Logger) logOutput(serviceName, serviceOutput string) {
+	if printColor, exists := l.getColor(serviceName); exists {
 		regularColor := color.New(printColor)
 		boldColor := color.New(printColor, color.Bold)
-		fmt.Printf("%s %s\n", boldColor.Sprintf(logger.pad(serviceName)), regularColor.Sprintf(serviceOutput))
+		fmt.Printf("%s %s\n", boldColor.Sprintf(l.pad(serviceName)), regularColor.Sprintf(serviceOutput))
 	} else {
 		boldColor := color.New(color.Bold)
-		fmt.Printf("%s %s\n", boldColor.Sprintf(logger.pad(serviceName)), serviceOutput)
+		fmt.Printf("%s %s\n", boldColor.Sprintf(l.pad(serviceName)), serviceOutput)
 	}
 }
 
-func (logger *Logger) setColors(roles []string) {
-	defaultColors := logger.getDefaultColors()
+func (l *Logger) setColors(roles []string) {
+	defaultColors := l.getDefaultColors()
 	for i, role := range roles {
-		logger.Colors[role] = defaultColors[i%len(defaultColors)]
+		l.Colors[role] = defaultColors[i%len(defaultColors)]
 	}
 }
 
-func (logger *Logger) setLength(roles []string) {
+func (l *Logger) setLength(roles []string) {
 	for _, role := range roles {
-		if len(role) > logger.Length {
-			logger.Length = len(role)
+		if len(role) > l.Length {
+			l.Length = len(role)
 		}
 	}
 }
 
-func (logger *Logger) pad(text string) string {
-	return pad.Left(text, logger.Length, " ")
+func (l *Logger) pad(text string) string {
+	return pad.Left(text, l.Length, " ")
 }

--- a/exo-go/src/process_helpers/process.go
+++ b/exo-go/src/process_helpers/process.go
@@ -28,7 +28,7 @@ func NewProcess(commandWords ...string) *Process {
 
 func (p *Process) isRunning() bool {
 	err := p.Cmd.Process.Signal(syscall.Signal(0))
-	return fmt.Sprint(err) != "os: p already finished"
+	return fmt.Sprint(err) != "os: process already finished"
 }
 
 // Kill kills the p if it is running

--- a/exo-go/src/types/dependency_config.go
+++ b/exo-go/src/types/dependency_config.go
@@ -10,6 +10,10 @@ type DependencyConfig struct {
 }
 
 // IsEmpty returns true if the given dependencyConfig object is empty
-func (dependencyConfig *DependencyConfig) IsEmpty() bool {
-	return len(dependencyConfig.Ports) == 0 && len(dependencyConfig.Volumes) == 0 && len(dependencyConfig.OnlineText) == 0 && len(dependencyConfig.DependencyEnvironment) == 0 && len(dependencyConfig.ServiceEnvironment) == 0
+func (d *DependencyConfig) IsEmpty() bool {
+	return len(d.Ports) == 0 &&
+		len(d.Volumes) == 0 &&
+		d.OnlineText == "" &&
+		len(d.DependencyEnvironment) == 0 &&
+		len(d.ServiceEnvironment) == 0
 }


### PR DESCRIPTION
* Use pointer receivers everywhere so we can modify the struct if needed. Otherwise you get a copy of the object and thus can't edit it.
* Make the variables a single letter as they are essentially the `this` we were using in javascript and we are likely to use it everywhere.
