### PR TITLE
remove unit test output

### DIFF
--- a/exo-go/src/app_runner/index.go
+++ b/exo-go/src/app_runner/index.go
@@ -107,12 +107,15 @@ func (a *AppRunner) waitForOnlineText(process *processHelpers.Process, role, onl
 		return err
 	}
 	if err = process.WaitForRegex(onlineTextRegex); err == nil {
-		a.Logger.Log(role, fmt.Sprintf("'%s' is running", role), true)
+		return a.Logger.Log(role, fmt.Sprintf("'%s' is running", role), true)
 	}
 	return nil
 }
 
 // write logs exo-run output
 func (a *AppRunner) write(text string) {
-	a.Logger.Log("exo-run", text, true)
+	err := a.Logger.Log("exo-run", text, true)
+	if err != nil {
+		fmt.Printf("Error logging exo-run output: %v\n", err)
+	}
 }

--- a/exo-go/src/app_setup/index.go
+++ b/exo-go/src/app_setup/index.go
@@ -1,6 +1,7 @@
 package appSetup
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 
@@ -125,5 +126,8 @@ func (a *AppSetup) Setup() error {
 
 // Write logs exo-run output
 func (a *AppSetup) Write(text string) {
-	a.Logger.Log("exo-run", text, true)
+	err := a.Logger.Log("exo-run", text, true)
+	if err != nil {
+		fmt.Printf("Error logging exo-run output: %v\n", err)
+	}
 }

--- a/exo-go/src/app_setup/index_test.go
+++ b/exo-go/src/app_setup/index_test.go
@@ -2,6 +2,7 @@ package appSetup_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"regexp"
@@ -44,7 +45,9 @@ var _ = Describe("Setup", func() {
 		}
 		appConfig, err := appConfigHelpers.GetAppConfig(appDir)
 		Expect(err).NotTo(HaveOccurred())
-		setup, err := appSetup.NewAppSetup(appConfig, logger.NewLogger([]string{}, []string{}), appDir, homeDir)
+		_, pipeWriter := io.Pipe()
+		mockLogger := logger.NewLogger([]string{}, []string{}, pipeWriter)
+		setup, err := appSetup.NewAppSetup(appConfig, mockLogger, appDir, homeDir)
 		Expect(err).NotTo(HaveOccurred())
 		err = setup.Setup()
 		Expect(err).NotTo(HaveOccurred())

--- a/exo-go/src/cmd/run.go
+++ b/exo-go/src/cmd/run.go
@@ -42,7 +42,7 @@ var runCmd = &cobra.Command{
 
 		roles := append(serviceNames, dependencyNames...)
 		roles = append(roles, "exo-run")
-		logger := logger.NewLogger(roles, append(silencedServiceNames, silencedDependencyNames...))
+		logger := logger.NewLogger(roles, append(silencedServiceNames, silencedDependencyNames...), os.Stdout)
 
 		appRunner := appRunner.NewAppRunner(appConfig, logger, appDir, homeDir)
 		wg := new(sync.WaitGroup)

--- a/exo-go/src/docker_setup/index_test.go
+++ b/exo-go/src/docker_setup/index_test.go
@@ -1,6 +1,7 @@
 package dockerSetup_test
 
 import (
+	"io"
 	"path"
 	"regexp"
 
@@ -38,12 +39,13 @@ var _ = Describe("GetServiceDockerConfigs", func() {
 				Expect(err).NotTo(HaveOccurred())
 				serviceData := serviceConfigHelpers.GetServiceData(appConfig.Services)
 				serviceName := "mongo"
+				_, pipeWriter := io.Pipe()
 				setup := &dockerSetup.DockerSetup{
 					AppConfig:     appConfig,
 					ServiceConfig: serviceConfigs[serviceName],
 					ServiceData:   serviceData[serviceName],
 					Role:          serviceName,
-					Logger:        logger.NewLogger([]string{}, []string{}),
+					Logger:        logger.NewLogger([]string{}, []string{}, pipeWriter),
 					AppDir:        appDir,
 					HomeDir:       homeDir,
 				}
@@ -94,12 +96,13 @@ var _ = Describe("GetServiceDockerConfigs", func() {
 				Expect(err).NotTo(HaveOccurred())
 				serviceData := serviceConfigHelpers.GetServiceData(appConfig.Services)
 				serviceName := "users-service"
+				_, pipeWriter := io.Pipe()
 				setup := &dockerSetup.DockerSetup{
 					AppConfig:     appConfig,
 					ServiceConfig: serviceConfigs[serviceName],
 					ServiceData:   serviceData[serviceName],
 					Role:          serviceName,
-					Logger:        logger.NewLogger([]string{}, []string{}),
+					Logger:        logger.NewLogger([]string{}, []string{}, pipeWriter),
 					AppDir:        appDir,
 					HomeDir:       homeDir,
 				}

--- a/exo-go/src/logger/index.go
+++ b/exo-go/src/logger/index.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/Originate/exosphere/exo-go/src/util"
@@ -15,11 +16,17 @@ type Logger struct {
 	SilencedRoles []string
 	Length        int
 	Colors        map[string]color.Attribute
+	Writer        io.Writer
 }
 
 // NewLogger is Logger's constructor
-func NewLogger(roles, silencedRoles []string) *Logger {
-	logger := &Logger{Roles: roles, SilencedRoles: silencedRoles, Colors: map[string]color.Attribute{}}
+func NewLogger(roles, silencedRoles []string, writer io.Writer) *Logger {
+	logger := &Logger{
+		Roles:         roles,
+		SilencedRoles: silencedRoles,
+		Colors:        map[string]color.Attribute{},
+		Writer:        writer,
+	}
 	logger.setColors(roles)
 	logger.setLength(roles)
 	return logger
@@ -51,10 +58,10 @@ func (l *Logger) logOutput(serviceName, serviceOutput string) {
 	if printColor, exists := l.getColor(serviceName); exists {
 		regularColor := color.New(printColor)
 		boldColor := color.New(printColor, color.Bold)
-		fmt.Printf("%s %s\n", boldColor.Sprintf(l.pad(serviceName)), regularColor.Sprintf(serviceOutput))
+		fmt.Fprintf(l.Writer, "%s %s\n", boldColor.Sprintf(l.pad(serviceName)), regularColor.Sprintf(serviceOutput))
 	} else {
 		boldColor := color.New(color.Bold)
-		fmt.Printf("%s %s\n", boldColor.Sprintf(l.pad(serviceName)), serviceOutput)
+		fmt.Fprintf(l.Writer, "%s %s\n", boldColor.Sprintf(l.pad(serviceName)), serviceOutput)
 	}
 }
 

--- a/exo-go/src/logger/index.go
+++ b/exo-go/src/logger/index.go
@@ -42,27 +42,30 @@ func (l *Logger) getDefaultColors() []color.Attribute {
 }
 
 // Log logs the given text
-func (l *Logger) Log(role, text string, trim bool) {
+func (l *Logger) Log(role, text string, trim bool) error {
 	if trim {
 		text = strings.TrimSpace(text)
 	}
 	for _, line := range strings.Split(text, `\n`) {
 		serviceName, serviceOutput := util.ParseDockerComposeLog(role, line)
 		if !util.DoesStringArrayContain(l.SilencedRoles, serviceName) {
-			l.logOutput(serviceName, serviceOutput)
+			err := l.logOutput(serviceName, serviceOutput)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
-func (l *Logger) logOutput(serviceName, serviceOutput string) {
+func (l *Logger) logOutput(serviceName, serviceOutput string) error {
+	prefix := color.New(color.Bold).Sprintf(l.pad(serviceName))
+	content := serviceOutput
 	if printColor, exists := l.getColor(serviceName); exists {
-		regularColor := color.New(printColor)
-		boldColor := color.New(printColor, color.Bold)
-		fmt.Fprintf(l.Writer, "%s %s\n", boldColor.Sprintf(l.pad(serviceName)), regularColor.Sprintf(serviceOutput))
-	} else {
-		boldColor := color.New(color.Bold)
-		fmt.Fprintf(l.Writer, "%s %s\n", boldColor.Sprintf(l.pad(serviceName)), serviceOutput)
+		content = color.New(printColor).Sprintf(serviceOutput)
 	}
+	_, err := fmt.Fprintf(l.Writer, "%s %s\n", prefix, content)
+	return err
 }
 
 func (l *Logger) setColors(roles []string) {


### PR DESCRIPTION
updates the logger to take in an io.Writer so we aren't outputting anything in the unit tests. We simply pass in os.Stdout when we want it to log things.
