### PR TITLE
Support multiple GOPATHs

### DIFF
--- a/exo-go/bin/build
+++ b/exo-go/bin/build
@@ -2,4 +2,5 @@
 set -e
 
 bin/build_bin_data
-go build -o $GOPATH/bin/exo
+bin_path=$(echo "$GOPATH" | tr ':' ' ' | awk '{print $NF}')
+go build -o "$bin_path/bin/exo"


### PR DESCRIPTION
It is possible to define multiple GOPATHs (see https://github.com/Originate/guide/blob/master/go/install.md#linux). This PR makes the `build` command use the last GOPATH it finds.