### PR TITLE
make service restarter test more reliable

### DIFF
--- a/exo-go/features/run/restart-service.feature
+++ b/exo-go/features/run/restart-service.feature
@@ -12,5 +12,6 @@ Feature: automatically restart a service when a change occurs
     And starting "exo run" in my application directory
     And it prints "all dependencies online" in the terminal
     And it prints "all services online" in the terminal
+    And it prints "watching ./mongo-service for changes" in the terminal
     When adding a file to "mongo-service" service folder
     Then the "users" service restarts

--- a/exo-go/src/application/service_restarter.go
+++ b/exo-go/src/application/service_restarter.go
@@ -42,6 +42,7 @@ func (s *serviceRestarter) Watch(watcherErrChannel chan<- error) {
 	if err := watcher.Add(s.ServiceDir); err != nil {
 		watcherErrChannel <- err
 	}
+	s.LogChannel <- fmt.Sprintf("watching %s for changes", s.ServiceDir)
 }
 
 func (s *serviceRestarter) restart(watcherErrChannel chan<- error) {


### PR DESCRIPTION
@mcharawi and I each saw this randomly fail. I believe it was because the directory was changed before the file watcher was started 
