### PR TITLE
add ability to specify template tag/commit

### DIFF
--- a/exo-go/bin/feature-test
+++ b/exo-go/bin/feature-test
@@ -2,4 +2,4 @@
 set -e
 
 go build --race -o $GOPATH/bin/exo
-go test
+go test -- $@

--- a/exo-go/features/help.feature
+++ b/exo-go/features/help.feature
@@ -80,7 +80,7 @@ Feature: help command
 
       Available Commands:
         add         Adds a remote service template to .exosphere
-        fetch       Fetches updates for all existing templates
+        fetch       Fetches updates for an existing service template in .exosphere
         remove      Removes an existing service template from .exosphere
       """
 
@@ -92,7 +92,7 @@ Feature: help command
       Adds a remote service template to .exosphere
 
       Usage:
-        exo template add <name> <url>
+        exo template add <name> <url> [<commit-ish>]
       """
 
 
@@ -100,10 +100,10 @@ Feature: help command
     When running "exo template fetch help" in the terminal
     Then I see:
       """
-      Fetches updates for all existing git submodules in the .exosphere folder
+      Fetches updates for an existing service template in .exosphere
 
       Usage:
-        exo template fetch
+        exo template fetch <name>
       """
 
 

--- a/exo-go/features/template/add_template/add_template.feature
+++ b/exo-go/features/template/add_template/add_template.feature
@@ -16,7 +16,6 @@ Feature: adding remote templates
     When running "exo template add boilr-license https://github.com/tmrts/boilr-license.git" in my application directory
     Then my application contains the directory ".exosphere/boilr-license"
     And my git repository has a submodule ".exosphere/boilr-license" with remote "https://github.com/tmrts/boilr-license.git"
-    And my git repository has a submodule ".exosphere/boilr-license" at commit "afb2fa6"
 
   Scenario: adding a new service template with a tag
     When running "exo template add boilr-license https://github.com/tmrts/boilr-license.git 0.0.1" in my application directory

--- a/exo-go/features/template/add_template/add_template.feature
+++ b/exo-go/features/template/add_template/add_template.feature
@@ -13,9 +13,15 @@ Feature: adding remote templates
 
 
   Scenario: adding a new service template
-    When running "exo template add boilr-spark https://github.com/tmrts/boilr-spark.git" in my application directory
-    Then my application contains the directory ".exosphere/boilr-spark"
-    And my git repository has a submodule ".exosphere/boilr-spark" with remote "https://github.com/tmrts/boilr-spark.git"
+    When running "exo template add boilr-license https://github.com/tmrts/boilr-license.git" in my application directory
+    Then my application contains the directory ".exosphere/boilr-license"
+    And my git repository has a submodule ".exosphere/boilr-license" with remote "https://github.com/tmrts/boilr-license.git"
+    And my git repository has a submodule ".exosphere/boilr-license" at commit "afb2fa6"
+
+  Scenario: adding a new service template with a tag
+    When running "exo template add boilr-license https://github.com/tmrts/boilr-license.git 0.0.1" in my application directory
+    Then my application contains the directory ".exosphere/boilr-license"
+    And my git repository has a submodule ".exosphere/boilr-license" at commit "4ea0b49"
 
 
   Scenario: the service template already exists and is not overwritten

--- a/exo-go/features/template/add_template/missing_arguments.feature
+++ b/exo-go/features/template/add_template/missing_arguments.feature
@@ -4,19 +4,19 @@ Feature: missing arguments
     Given I am in the root directory of an empty application called "test app"
     And my application is a Git repository
 
-  Scenario: attempting to run exo add-template without specifying template name or URL
+  Scenario: attempting to run 'exo template add' without specifying template name or URL
     When starting "exo template add" in my application directory
     Then I see:
       """
-      not enough arguments
+      wrong number of arguments
       """
     And it exits with code 1
 
 
-  Scenario: attempting to run exo add-template without git URL
+  Scenario: attempting to run 'exo template add' without git URL
     When starting "exo template add foo" in my application directory
     Then I see:
       """
-      not enough arguments
+      wrong number of arguments
       """
     And it exits with code 1

--- a/exo-go/features/template/fetch_templates/fetch_templates.feature
+++ b/exo-go/features/template/fetch_templates/fetch_templates.feature
@@ -12,5 +12,5 @@ Feature: fetching updates for existing templates
     And my application has the templates:
       | NAME        | URL                                      |
       | boilr-spark | https://github.com/tmrts/boilr-spark.git |
-    When running "exo template fetch" in my application directory
+    When running "exo template fetch boilr-spark" in my application directory
     Then it prints "done" in the terminal

--- a/exo-go/features/template/fetch_templates/missing_arguments.feature
+++ b/exo-go/features/template/fetch_templates/missing_arguments.feature
@@ -1,10 +1,12 @@
 Feature: missing arguments
 
-  Scenario: attempting to run 'exo template remove' without specifying template name
+  Background:
     Given I am in the root directory of an empty application called "test app"
     And my application is a Git repository
-    When starting "exo template remove" in my application directory
-    Then I eventually see:
+
+  Scenario: attempting to run `exo template fetch` without specifying template name
+    When starting "exo template fetch" in my application directory
+    Then I see:
       """
       wrong number of arguments
       """

--- a/exo-go/features/tutorial.feature
+++ b/exo-go/features/tutorial.feature
@@ -55,7 +55,7 @@ Feature: Following the tutorial
     ########################################
     # Adding the html service
     ########################################
-    Given running "exo template add exosphere-htmlserver-express https://github.com/Originate/exosphere-htmlserver-express.git#v0.22.1" in my application directory
+    Given running "exo template add exosphere-htmlserver-express https://github.com/Originate/exosphere-htmlserver-express.git v0.22.1" in my application directory
     When starting "exo add" in my application directory
     And entering into the wizard:
       | FIELD                         | INPUT                            |
@@ -123,7 +123,7 @@ Feature: Following the tutorial
     ########################################
     # adding the todo service
     ########################################
-    Given running "exo template add exoservice-js-mongodb https://github.com/Originate/exoservice-js-mongodb.git#v0.22.1" in my application directory
+    Given running "exo template add exoservice-js-mongodb https://github.com/Originate/exoservice-js-mongodb.git v0.22.1" in my application directory
     When starting "exo add" in my application directory
     And entering into the wizard:
       | FIELD                         | INPUT                    |

--- a/exo-go/features/tutorial.feature
+++ b/exo-go/features/tutorial.feature
@@ -55,7 +55,7 @@ Feature: Following the tutorial
     ########################################
     # Adding the html service
     ########################################
-    Given running "exo template add exosphere-htmlserver-express https://github.com/Originate/exosphere-htmlserver-express.git" in my application directory
+    Given running "exo template add exosphere-htmlserver-express https://github.com/Originate/exosphere-htmlserver-express.git#v0.22.1" in my application directory
     When starting "exo add" in my application directory
     And entering into the wizard:
       | FIELD                         | INPUT                            |
@@ -123,7 +123,7 @@ Feature: Following the tutorial
     ########################################
     # adding the todo service
     ########################################
-    Given running "exo template add exoservice-js-mongodb https://github.com/Originate/exoservice-js-mongodb.git" in my application directory
+    Given running "exo template add exoservice-js-mongodb https://github.com/Originate/exoservice-js-mongodb.git#v0.22.1" in my application directory
     When starting "exo add" in my application directory
     And entering into the wizard:
       | FIELD                         | INPUT                    |

--- a/exo-go/src/cmd/template.go
+++ b/exo-go/src/cmd/template.go
@@ -17,25 +17,29 @@ var templateCmd = &cobra.Command{
 }
 
 var addTemplateCmd = &cobra.Command{
-	Use:   "add <name> <url>",
+	Use:   "add <name> <url> [<commit-ish>]",
 	Short: "Adds a remote service template to .exosphere",
 	Long:  "Adds a remote service template to .exosphere",
 	Run: func(cmd *cobra.Command, args []string) {
 		if printHelpIfNecessary(cmd, args) {
 			return
 		}
-		if len(args) != 2 {
-			fmt.Println("not enough arguments")
+		if len(args) != 2 && len(args) != 3 {
+			fmt.Println("wrong number of arguments")
 			os.Exit(1)
 		}
 		fmt.Print("We are about to add a new service template\n")
 		templateName, gitURL := args[0], args[1]
+		commitIsh := ""
+		if len(args) == 3 {
+			commitIsh = args[2]
+		}
 		templateDir := path.Join(".exosphere", templateName)
 		if util.DoesDirectoryExist(templateDir) {
 			fmt.Printf(`The template "%s" already exists\n`, templateName)
 			os.Exit(1)
 		} else {
-			if err := template.Add(gitURL, templateName, templateDir); err != nil {
+			if err := template.Add(gitURL, templateName, templateDir, commitIsh); err != nil {
 				panic(err)
 			}
 		}
@@ -44,15 +48,21 @@ var addTemplateCmd = &cobra.Command{
 }
 
 var fetchTemplatesCmd = &cobra.Command{
-	Use:   "fetch",
-	Short: "Fetches updates for all existing templates",
-	Long:  "Fetches updates for all existing git submodules in the .exosphere folder",
+	Use:   "fetch <name>",
+	Short: "Fetches updates for an existing service template in .exosphere",
+	Long:  "Fetches updates for an existing service template in .exosphere",
 	Run: func(cmd *cobra.Command, args []string) {
 		if printHelpIfNecessary(cmd, args) {
 			return
 		}
-		fmt.Print("We are about to fetch updates for the remote templates\n\n")
-		if err := template.Fetch(); err != nil {
+		if len(args) != 1 {
+			fmt.Println("wrong number of arguments")
+			os.Exit(1)
+		}
+		templateName := args[0]
+		templateDir := path.Join(".exosphere", templateName)
+		fmt.Print("We are about to fetch updates for the template  \"%s\"\n\n", templateName)
+		if err := template.Fetch(templateDir); err != nil {
 			panic(err)
 		}
 		fmt.Println("\ndone")
@@ -68,7 +78,7 @@ var removeTemplateCmd = &cobra.Command{
 			return
 		}
 		if len(args) != 1 {
-			fmt.Println("not enough arguments")
+			fmt.Println("wrong number of arguments")
 			os.Exit(1)
 		}
 		templateName := args[0]

--- a/exo-go/src/cmd/template.go
+++ b/exo-go/src/cmd/template.go
@@ -61,7 +61,7 @@ var fetchTemplatesCmd = &cobra.Command{
 		}
 		templateName := args[0]
 		templateDir := path.Join(".exosphere", templateName)
-		fmt.Print("We are about to fetch updates for the template  \"%s\"\n\n", templateName)
+		fmt.Printf("We are about to fetch updates for the template  \"%s\"\n\n", templateName)
 		if err := template.Fetch(templateDir); err != nil {
 			panic(err)
 		}

--- a/exo-go/src/template/index.go
+++ b/exo-go/src/template/index.go
@@ -7,7 +7,6 @@ import (
 	"path"
 
 	"github.com/Originate/exosphere/exo-go/src/util"
-	"github.com/pkg/errors"
 	"github.com/tmrts/boilr/pkg/template"
 )
 
@@ -16,12 +15,12 @@ const templatesDir = ".exosphere"
 // Add fetches a remote template from GitHub and stores it
 // under templateDir, returns an error if any
 func Add(gitURL, templateName, templateDir, commitIsh string) error {
-	if output, err := util.Run("", "git", "submodule", "add", "--name", templateName, gitURL, templateDir); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed to fetch template from %s: %s\n", gitURL, output))
+	if _, err := util.Run("", "git", "submodule", "add", "--name", templateName, gitURL, templateDir); err != nil {
+		return err
 	}
 	if commitIsh != "" {
-		if output, err := util.Run(templateDir, "git", "checkout", commitIsh); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to checkout %s: %s\n", commitIsh, output))
+		if _, err := util.Run(templateDir, "git", "checkout", commitIsh); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -48,8 +47,8 @@ func CreateTmpServiceDir(appDir, chosenTemplate string) (string, error) {
 
 // Fetch fetches updates for all existing remote templates
 func Fetch(templateDir string) error {
-	if output, err := util.Run(templateDir, "git", "submodule", "foreach", "git", "pull"); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed to fetch updates for existing templates: %s\n", output))
+	if _, err := util.Run(templateDir, "git", "pull"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/exo-go/src/template/index.go
+++ b/exo-go/src/template/index.go
@@ -43,7 +43,7 @@ func CreateTmpServiceDir(appDir, chosenTemplate string) (string, error) {
 
 // Fetch fetches updates for all existing remote templates
 func Fetch() error {
-	if output, err := util.Run("", "git", "submodule", "foreach", "git", "pull", "origin", "master"); err != nil {
+	if output, err := util.Run("", "git", "submodule", "foreach", "git", "pull"); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to fetch updates for existing templates: %s\n", output))
 	}
 	return nil

--- a/exo-go/src/template/index.go
+++ b/exo-go/src/template/index.go
@@ -19,9 +19,8 @@ func Add(gitURL, templateName, templateDir, commitIsh string) error {
 		return err
 	}
 	if commitIsh != "" {
-		if _, err := util.Run(templateDir, "git", "checkout", commitIsh); err != nil {
-			return err
-		}
+		_, err := util.Run(templateDir, "git", "checkout", commitIsh)
+		return err
 	}
 	return nil
 }
@@ -47,10 +46,8 @@ func CreateTmpServiceDir(appDir, chosenTemplate string) (string, error) {
 
 // Fetch fetches updates for all existing remote templates
 func Fetch(templateDir string) error {
-	if _, err := util.Run(templateDir, "git", "pull"); err != nil {
-		return err
-	}
-	return nil
+	_, err := util.Run(templateDir, "git", "pull")
+	return err
 }
 
 // GetTemplates returns a slice of all template names found in the ".exosphere"

--- a/exo-go/src/template/index.go
+++ b/exo-go/src/template/index.go
@@ -15,9 +15,14 @@ const templatesDir = ".exosphere"
 
 // Add fetches a remote template from GitHub and stores it
 // under templateDir, returns an error if any
-func Add(gitURL, templateName, templateDir string) error {
+func Add(gitURL, templateName, templateDir, commitIsh string) error {
 	if output, err := util.Run("", "git", "submodule", "add", "--name", templateName, gitURL, templateDir); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to fetch template from %s: %s\n", gitURL, output))
+	}
+	if commitIsh != "" {
+		if output, err := util.Run(templateDir, "git", "checkout", commitIsh); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to checkout %s: %s\n", commitIsh, output))
+		}
 	}
 	return nil
 }
@@ -42,8 +47,8 @@ func CreateTmpServiceDir(appDir, chosenTemplate string) (string, error) {
 }
 
 // Fetch fetches updates for all existing remote templates
-func Fetch() error {
-	if output, err := util.Run("", "git", "submodule", "foreach", "git", "pull"); err != nil {
+func Fetch(templateDir string) error {
+	if output, err := util.Run(templateDir, "git", "submodule", "foreach", "git", "pull"); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to fetch updates for existing templates: %s\n", output))
 	}
 	return nil

--- a/exo-go/test_helpers/template_feature_context.go
+++ b/exo-go/test_helpers/template_feature_context.go
@@ -54,6 +54,16 @@ func TemplateFeatureContext(s *godog.Suite) {
 		}
 	})
 
+	s.Step(`^my git repository has a submodule "([^"]*)" at commit "([^"]*)"$`, func(submodulePath, commitSha string) error {
+		fullSubmodulePath := path.Join(appDir, submodulePath)
+		if childOutput, err := util.Run(fullSubmodulePath, "git", "rev-parse", "HEAD"); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Failed to read git config file: %s", childOutput))
+		} else {
+			fmt.Println(childOutput)
+			return validateTextContains(childOutput, commitSha)
+		}
+	})
+
 	s.Step(`^my git repository does not have any submodules$`, func() error {
 		if !util.IsEmptyDirectory(path.Join(appDir, ".exosphere")) || !util.IsEmptyFile(path.Join(appDir, ".gitmodules")) || !util.IsEmptyDirectory(path.Join(appDir, ".git", "modules")) {
 			return fmt.Errorf("Expected the git reposity to not have any submodules")


### PR DESCRIPTION
resolves #407 

* Updated the fetch command to only fetch updates for a single template since those updated via a tag shouldn't/can't be updated.
* Removed some error wrapping as util.Run now gives good error messages that include the command being run and the output