### PR TITLE
[stabilize 1] update timeout

### DIFF
--- a/bin/feature-test
+++ b/bin/feature-test
@@ -2,4 +2,4 @@
 set -e
 
 go install --race github.com/Originate/exosphere/src/cmd/exo
-go test -- $@
+go test -timeout 20m -- $@

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/godog"
@@ -9,12 +10,14 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	var format string
+	format := "pretty"
 	var paths []string
-	if len(os.Args) == 3 && os.Args[1] == "--" {
-		format = "pretty"
-		paths = append(paths, os.Args[2])
-	} else {
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "features/") {
+			paths = append(paths, arg)
+		}
+	}
+	if len(paths) == 0 {
 		format = "progress"
 		paths = append(paths, "features")
 	}


### PR DESCRIPTION
`go test` panics if it runs for more than 10 minutes. This was all the SIGQUIT we were running into on CI. Bump that timeout to 20 minutes. This also says something about our tests that they run too long. We should revisit working to drop this down