### PR TITLE
rename a couple types

### DIFF
--- a/src/config/app_dependency.go
+++ b/src/config/app_dependency.go
@@ -15,7 +15,7 @@ type AppDependency interface {
 }
 
 // NewAppDependency returns an AppDependency
-func NewAppDependency(dependency types.Dependency, appConfig types.AppConfig, appDir, homeDir string) AppDependency {
+func NewAppDependency(dependency types.DependencyConfig, appConfig types.AppConfig, appDir, homeDir string) AppDependency {
 	switch dependency.Name {
 	case "exocom":
 		return &exocomDependency{dependency, appConfig, appDir}

--- a/src/config/app_dependency_test.go
+++ b/src/config/app_dependency_test.go
@@ -168,7 +168,7 @@ var _ = Describe("AppDependency", func() {
 		var nats config.AppDependency
 
 		var _ = BeforeEach(func() {
-			nats = config.NewAppDependency(types.Dependency{
+			nats = config.NewAppDependency(types.DependencyConfig{
 				Name:    "nats",
 				Version: "0.9.6",
 			}, appConfig, appDir, homeDir)

--- a/src/config/exocom_dependency.go
+++ b/src/config/exocom_dependency.go
@@ -9,7 +9,7 @@ import (
 )
 
 type exocomDependency struct {
-	config    types.Dependency
+	config    types.DependencyConfig
 	appConfig types.AppConfig
 	appDir    string
 }

--- a/src/config/generic_dependency.go
+++ b/src/config/generic_dependency.go
@@ -8,7 +8,7 @@ import (
 )
 
 type genericDependency struct {
-	config    types.Dependency
+	config    types.DependencyConfig
 	appConfig types.AppConfig
 	appDir    string
 	homeDir   string

--- a/src/config/nats_dependency.go
+++ b/src/config/nats_dependency.go
@@ -7,7 +7,7 @@ import (
 )
 
 type natsDependency struct {
-	config    types.Dependency
+	config    types.DependencyConfig
 	appConfig types.AppConfig
 	appDir    string
 }

--- a/src/types/app_config.go
+++ b/src/types/app_config.go
@@ -15,7 +15,7 @@ type AppConfig struct {
 	Name         string
 	Description  string
 	Version      string
-	Dependencies []Dependency
+	Dependencies []DependencyConfig
 	Services     Services
 	Templates    map[string]string `yaml:",omitempty"`
 	Production   map[string]string `yaml:",omitempty"`

--- a/src/types/app_config_test.go
+++ b/src/types/app_config_test.go
@@ -26,15 +26,15 @@ var _ = Describe("AppConfig", func() {
 		})
 
 		It("should have all the dependencies", func() {
-			Expect(appConfig.Dependencies).To(Equal([]types.Dependency{
-				types.Dependency{
+			Expect(appConfig.Dependencies).To(Equal([]types.DependencyConfig{
+				types.DependencyConfig{
 					Name:    "exocom",
 					Version: "0.24.0",
 				},
-				types.Dependency{
+				types.DependencyConfig{
 					Name:    "mongo",
 					Version: "3.4.0",
-					Config: types.DependencyConfig{
+					Config: types.DependencyConfigOptions{
 						Ports:                 []string{"4000:4000"},
 						Volumes:               []string{"{{EXO_DATA_PATH}}:/data/db"},
 						OnlineText:            "waiting for connections",
@@ -69,7 +69,7 @@ var _ = Describe("AppConfig", func() {
 	var _ = Describe("GetDependencyNames", func() {
 		It("should return the names of all application dependencies", func() {
 			appConfig := types.AppConfig{
-				Dependencies: []types.Dependency{
+				Dependencies: []types.DependencyConfig{
 					{Name: "exocom"},
 					{Name: "mongo"},
 				},
@@ -102,7 +102,7 @@ var _ = Describe("AppConfig", func() {
 	var _ = Describe("GetSilencedDependencyNames", func() {
 		It("should return the names of all silenced dependencies", func() {
 			appConfig := types.AppConfig{
-				Dependencies: []types.Dependency{
+				Dependencies: []types.DependencyConfig{
 					{Name: "exocom", Silent: true},
 					{Name: "mongo"},
 				},

--- a/src/types/dependency.go
+++ b/src/types/dependency.go
@@ -1,9 +1,0 @@
-package types
-
-// Dependency represents a dependency of an application
-type Dependency struct {
-	Name    string
-	Version string
-	Silent  bool             `yaml:",omitempty"`
-	Config  DependencyConfig `yaml:",omitempty"`
-}

--- a/src/types/dependency_config.go
+++ b/src/types/dependency_config.go
@@ -1,19 +1,9 @@
 package types
 
-// DependencyConfig represents the configuration of a dependency
+// DependencyConfig represents a dependency of an application
 type DependencyConfig struct {
-	Ports                 []string          `yaml:",omitempty"`
-	Volumes               []string          `yaml:",omitempty"`
-	OnlineText            string            `yaml:"online-text,omitempty"`
-	DependencyEnvironment map[string]string `yaml:"dependency-environment,omitempty"`
-	ServiceEnvironment    map[string]string `yaml:"service-environment,omitempty"`
-}
-
-// IsEmpty returns true if the given dependencyConfig object is empty
-func (d *DependencyConfig) IsEmpty() bool {
-	return len(d.Ports) == 0 &&
-		len(d.Volumes) == 0 &&
-		d.OnlineText == "" &&
-		len(d.DependencyEnvironment) == 0 &&
-		len(d.ServiceEnvironment) == 0
+	Name    string
+	Version string
+	Silent  bool                    `yaml:",omitempty"`
+	Config  DependencyConfigOptions `yaml:",omitempty"`
 }

--- a/src/types/dependency_config_options.go
+++ b/src/types/dependency_config_options.go
@@ -1,0 +1,19 @@
+package types
+
+// DependencyConfigOptions represents the configuration of a dependency
+type DependencyConfigOptions struct {
+	Ports                 []string          `yaml:",omitempty"`
+	Volumes               []string          `yaml:",omitempty"`
+	OnlineText            string            `yaml:"online-text,omitempty"`
+	DependencyEnvironment map[string]string `yaml:"dependency-environment,omitempty"`
+	ServiceEnvironment    map[string]string `yaml:"service-environment,omitempty"`
+}
+
+// IsEmpty returns true if the given dependencyConfig object is empty
+func (d *DependencyConfigOptions) IsEmpty() bool {
+	return len(d.Ports) == 0 &&
+		len(d.Volumes) == 0 &&
+		d.OnlineText == "" &&
+		len(d.DependencyEnvironment) == 0 &&
+		len(d.ServiceEnvironment) == 0
+}

--- a/src/types/service_config.go
+++ b/src/types/service_config.go
@@ -11,7 +11,7 @@ type ServiceConfig struct {
 	Restart         map[string]interface{} `yaml:",omitempty"`
 	Tests           string                 `yaml:",omitempty"`
 	ServiceMessages `yaml:"messages,omitempty"`
-	Docker          DockerConfig      `yaml:",omitempty"`
-	Dependencies    []Dependency      `yaml:",omitempty"`
-	Production      map[string]string `yaml:",omitempty"`
+	Docker          DockerConfig       `yaml:",omitempty"`
+	Dependencies    []DependencyConfig `yaml:",omitempty"`
+	Production      map[string]string  `yaml:",omitempty"`
 }


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #411 

types.DependencyConfig -> types.DependencyConfigOptions
types.Dependency -> types.DependencyConfig

Used a nice built in `go rename` tool
