### PR TITLE
update go-execplus

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1b3208dd616fcaec8fdd9b3aab5005a059177a0bd0dc0742c368516e6626294e
-updated: 2017-08-17T11:13:05.720969259-07:00
+hash: f9fa7d492b755176295700842a1aa0bdc7fd6d3db9d9946b3a1b6a6c8323691b
+updated: 2017-08-23T13:46:02.097961156-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 75d583c2afd3807d4d3f24b31b06feebb8849242
@@ -113,7 +113,7 @@ imports:
 - name: github.com/opencontainers/go-digest
   version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
 - name: github.com/Originate/go-execplus
-  version: bfb491ad50f3cb387768de0d442d93c81a5d33b3
+  version: e558a031bc731f517c919a95b52753e026b45849
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/satori/go.uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,9 +16,9 @@ import:
   version: 181d419aa9e2223811b824e8f0b4af96f9ba9302
 - package: github.com/aws/aws-sdk-go
   version: v1.10.19
-- package: github.com/Originate/go-execplus
-  version: v0.5.0
 - package: github.com/segmentio/go-prompt
+- package: github.com/Originate/go-execplus
+  version: v0.6.0
 testImport:
 - package: github.com/DATA-DOG/godog
   subpackages:

--- a/vendor/github.com/Originate/go-execplus/CHANGELOG.md
+++ b/vendor/github.com/Originate/go-execplus/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.0 (2017-08-23)
+
+* fix possible race condition in `Wait*` funcs
+
 # 0.5.0 (2017-08-17)
 
 * Stop sending output chunks in their own goroutine

--- a/vendor/github.com/Originate/go-execplus/CONTRIBUTING.md
+++ b/vendor/github.com/Originate/go-execplus/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 * Create a feature branch with the following
   * Update `CHANGELOG.md`
   * Update version in `execplus.go`
-* Get the feature branch reviewed and merged using the commit message `Release vX.Y.Z`
+* Get the feature branch reviewed
+* Squash merge using the commit message `Release vX.Y.Z`
 * Create and push a new Git tag for the release
   * `git tag vX.Y.Z`
   * `git push --tags`

--- a/vendor/github.com/Originate/go-execplus/cmd_plus_test.go
+++ b/vendor/github.com/Originate/go-execplus/cmd_plus_test.go
@@ -150,6 +150,22 @@ var _ = Describe("Process", func() {
 			err = cmdPlus.Kill()
 			Expect(err).To(BeNil())
 		})
+
+		It("works for sequential waits", func() {
+			cmdPlus := execplus.NewCmdPlus("./test_executables/output_chunks")
+			err := cmdPlus.Start()
+			Expect(err).To(BeNil())
+			err = cmdPlus.WaitForCondition(func(chunk, full string) bool {
+				return chunk == "chunk 1"
+			}, time.Second*2)
+			Expect(err).To(BeNil())
+			err = cmdPlus.WaitForCondition(func(chunk, full string) bool {
+				return chunk == "late chunk 4"
+			}, time.Second*8)
+			Expect(err).To(BeNil())
+			err = cmdPlus.Kill()
+			Expect(err).To(BeNil())
+		})
 	})
 
 	Describe("waitForRegexp", func() {

--- a/vendor/github.com/Originate/go-execplus/execplus.go
+++ b/vendor/github.com/Originate/go-execplus/execplus.go
@@ -1,4 +1,4 @@
 package execplus
 
 // Version of package - based on Semantic Versioning 2.0.0 http://semver.org/
-const Version = "v0.5.0"
+const Version = "v0.6.0"


### PR DESCRIPTION
There was a race condition in go-execplus in the `Wait*` functions that was causing deadlock. This appeared in my tests for the updates to the test command. Hopefully this helps make our tests more consistent.
