### PR TITLE
cleanup docker compose output

### DIFF
--- a/src/application/logger.go
+++ b/src/application/logger.go
@@ -49,10 +49,11 @@ func (l *Logger) GetLogChannel(role string) chan string {
 
 // Log logs the given text
 func (l *Logger) Log(role, text string, trim bool) error {
+	text = util.NormalizeDockerComposeLog(text)
 	if trim {
 		text = strings.TrimSpace(text)
 	}
-	for _, line := range strings.Split(text, `\n`) {
+	for _, line := range strings.Split(text, "\n") {
 		serviceName, serviceOutput := util.ParseDockerComposeLog(role, line)
 		if !util.DoesStringArrayContain(l.SilencedRoles, serviceName) {
 			err := l.logOutput(serviceName, serviceOutput)

--- a/src/application/runner.go
+++ b/src/application/runner.go
@@ -108,9 +108,9 @@ func (r *Runner) runImages(imageNames []string, imageOnlineTexts map[string]stri
 // Shutdown shuts down the application and returns the process output and an error if any
 func (r *Runner) Shutdown(shutdownConfig types.ShutdownConfig) error {
 	if len(shutdownConfig.ErrorMessage) > 0 {
-		color.Red(shutdownConfig.ErrorMessage)
+		r.logChannel <- color.New(color.FgRed).Sprint(shutdownConfig.ErrorMessage)
 	} else {
-		fmt.Printf("\n\n%s", shutdownConfig.CloseMessage)
+		r.logChannel <- shutdownConfig.CloseMessage
 	}
 	process, err := compose.KillAllContainers(compose.BaseOptions{
 		DockerComposeDir: r.DockerComposeDir,

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -43,7 +43,7 @@ var runCmd = &cobra.Command{
 		logger := application.NewLogger(roles, append(silencedServiceNames, silencedDependencyNames...), os.Stdout)
 		logChannel := logger.GetLogChannel("exo-run")
 
-		fmt.Printf("Setting up %s %s\n\n", appConfig.Name, appConfig.Version)
+		logChannel <- fmt.Sprintf("Setting up %s %s\n\n", appConfig.Name, appConfig.Version)
 		initializer, err := application.NewInitializer(appConfig, logChannel, logRole, appDir, homeDir)
 		if err != nil {
 			panic(err)
@@ -52,9 +52,9 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			panic(errors.Wrap(err, "setup failed"))
 		}
-		fmt.Println("setup complete")
+		logChannel <- "setup complete"
 
-		fmt.Printf("Running %s %s\n\n", appConfig.Name, appConfig.Version)
+		logChannel <- fmt.Sprintf("Running %s %s\n\n", appConfig.Name, appConfig.Version)
 		runner, err := application.NewRunner(appConfig, logger, logRole, appDir, homeDir)
 		if err != nil {
 			panic(err)

--- a/src/util/docker_log_test.go
+++ b/src/util/docker_log_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("GetServiceExitCode", func() {
+var _ = Describe("Docker Log Methods", func() {
 
 	It("should return the correct exit code", func() {
 		role := "tweets-service"
@@ -25,6 +25,26 @@ var _ = Describe("GetServiceExitCode", func() {
 
 })
 
+var _ = Describe("NormalizeDockerComposeLog", func() {
+	It("should remove colors", func() {
+		line := "\u001b[33mweb             |\u001b[0m web server running at port 4000"
+		result := util.NormalizeDockerComposeLog(line)
+		Expect(result).To(Equal("web             | web server running at port 4000"))
+	})
+
+	It("should remove VT100 control characters", func() {
+		line := "\u001b[1A\u001b[2KCreating exoservice ..."
+		result := util.NormalizeDockerComposeLog(line)
+		Expect(result).To(Equal("Creating exoservice ..."))
+	})
+
+	It("should transform carriage return character to newlines", func() {
+		line := "Creating exoservice ...\rdone"
+		result := util.NormalizeDockerComposeLog(line)
+		Expect(result).To(Equal("Creating exoservice ...\ndone"))
+	})
+})
+
 var _ = Describe("ParseDockerComposeLog", func() {
 
 	const role = "exo-run"
@@ -37,41 +57,17 @@ var _ = Describe("ParseDockerComposeLog", func() {
 	})
 
 	It("should parse service log message correctly", func() {
-		line := "\u001b[33mweb             |\u001b[0m web server running at port 4000"
+		line := "web             | web server running at port 4000"
 		serviceName, serviceOutput := util.ParseDockerComposeLog(role, line)
 		Expect(serviceName).To(Equal("web"))
 		Expect(serviceOutput).To(Equal("web server running at port 4000"))
 	})
 
 	It("should strip version from service name", func() {
-		line := "\u001b[36mexocom0.24.0    |\u001b[0m ExoCom HTTP service online at port 80"
+		line := "exocom0.24.0    | ExoCom HTTP service online at port 80"
 		serviceName, serviceOutput := util.ParseDockerComposeLog(role, line)
 		Expect(serviceName).To(Equal("exocom"))
 		Expect(serviceOutput).To(Equal("ExoCom HTTP service online at port 80"))
-	})
-
-})
-
-var _ = Describe("Map methods", func() {
-
-	It("merges maps", func() {
-		existingMap := map[string]string{
-			"var1": "val1",
-			"var2": "val2",
-			"var3": "val3",
-		}
-		newMap := map[string]string{
-			"var4": "val4",
-		}
-		expectedMap := map[string]string{
-			"var1": "val1",
-			"var2": "val2",
-			"var3": "val3",
-			"var4": "val4",
-		}
-		util.Merge(existingMap, newMap)
-
-		Expect(existingMap).To(Equal(expectedMap))
 	})
 
 })

--- a/src/util/map_test.go
+++ b/src/util/map_test.go
@@ -1,0 +1,31 @@
+package util_test
+
+import (
+	"github.com/Originate/exosphere/src/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Map methods", func() {
+	Describe("Merge", func() {
+		It("merges maps", func() {
+			existingMap := map[string]string{
+				"var1": "val1",
+				"var2": "val2",
+				"var3": "val3",
+			}
+			newMap := map[string]string{
+				"var4": "val4",
+			}
+			expectedMap := map[string]string{
+				"var1": "val1",
+				"var2": "val2",
+				"var3": "val3",
+				"var4": "val4",
+			}
+			util.Merge(existingMap, newMap)
+
+			Expect(existingMap).To(Equal(expectedMap))
+		})
+	})
+})


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #480 
resolves #482 

old output of exo test in sample app
```
  exo-test Testing application Application with end-to-end tests
  exo-test Testing service 'exoservice'
  exo-test The EXOCOM_PORT variable is not set. Defaulting to a blank string.
  exo-test The EXOCOM_PORT variable is not set. Defaulting to a blank string.
  exo-test Building exoservice
  exo-test Step 1/6 : FROM nodesource/node
  exo-test ---> f3e8701301ce
  exo-test Step 2/6 : COPY ./package.json .
  exo-test ---> Using cache
  exo-test ---> 48816f192e62
Step 3/6 : RUN curl -o- -L https://yarnpkg.com/install.sh bash
  exo-test ---> Using cache
  exo-test ---> 6d9a900a625b
  exo-test Step 4/6 : ENV NODE_ENV ""
  exo-test ---> Using cache
  exo-test ---> 1f4ce3de26cd
  exo-test Step 5/6 : RUN $HOME/.yarn/bin/yarn install
  exo-test ---> Using cache
  exo-test ---> fca8f64bd3a0
  exo-test Step 6/6 : COPY . .
  exo-test ---> Using cache
  exo-test ---> b8b2bbb50d15
  exo-test Successfully built b8b2bbb50d15
  exo-test Successfully tagged tmp_exoservice:latest
  exo-test Creating network "tmp_default" with the default driver
  exo-test Creating exoservice ...
  exo-test Creating exoservice
  exo-test Attaching to exoservice
exoservice Feature: Example test for scaffolded exo-services
exoservice 
exoservice As a developer having scaffolded a new exo-service
exoservice I want to see a running end-to-end test
exoservice So that I can start TDDing my service without having to set up the test framework myself.
exoservice 
exoservice - a new Exoservice contains an example Cucumber test for the "ping" command
exoservice - run "exo test" in your app dir to run all tests for all services of your application
exoservice - run "cucumber-js" in a service's directory to test only that service
exoservice 
exoservice Scenario: uptime checking
exoservice ✔ Given an ExoCom server
exoservice ✔ And an instance of this service
exoservice ✔ When receiving the "ping" command
exoservice ✔ Then this service replies with a "pong" message
exoservice 
exoservice 1 scenario (1 passed)
exoservice 4 steps (4 passed)
exoservice 0m00.064s
  exo-test exoservice exited with code 0
  exo-test all services online
  exo-test 'exoservice' tests passed


killing test containers
Creating exoservice ... done
  exo-test 
  exo-test The EXOCOM_PORT variable is not set. Defaulting to a blank string.
Removing exoservice ... done
Removing network tmp_default
  exo-test All tests passed
```

new output

```
  exo-test Testing application Application with end-to-end tests
  exo-test Testing service 'exoservice'
  exo-test The EXOCOM_PORT variable is not set. Defaulting to a blank string.
  exo-test The EXOCOM_PORT variable is not set. Defaulting to a blank string.
  exo-test Building exoservice
  exo-test Step 1/6 : FROM nodesource/node
  exo-test ---> f3e8701301ce
  exo-test Step 2/6 : COPY ./package.json .
  exo-test ---> Using cache
  exo-test ---> 48816f192e62
  exo-test Step 3/6 : RUN curl -o- -L https://yarnpkg.com/install.sh | bash
  exo-test ---> Using cache
  exo-test ---> 6d9a900a625b
  exo-test Step 4/6 : ENV NODE_ENV ""
  exo-test ---> Using cache
  exo-test ---> 1f4ce3de26cd
  exo-test Step 5/6 : RUN $HOME/.yarn/bin/yarn install
  exo-test ---> Using cache
  exo-test ---> fca8f64bd3a0
  exo-test Step 6/6 : COPY . .
  exo-test ---> Using cache
  exo-test ---> b8b2bbb50d15
  exo-test Successfully built b8b2bbb50d15
  exo-test Successfully tagged tmp_exoservice:latest
  exo-test Creating network "tmp_default" with the default driver
  exo-test Creating exoservice ...
  exo-test Creating exoservice
  exo-test Attaching to exoservice
exoservice Feature: Example test for scaffolded exo-services
exoservice 
exoservice     As a developer having scaffolded a new exo-service
exoservice     I want to see a running end-to-end test
exoservice     So that I can start TDDing my service without having to set up the test framework myself.
exoservice 
exoservice     - a new Exoservice contains an example Cucumber test for the "ping" command
exoservice     - run "exo test" in your app dir to run all tests for all services of your application
exoservice     - run "cucumber-js" in a service's directory to test only that service
exoservice 
exoservice   Scenario: uptime checking
exoservice   ✔ Given an ExoCom server
exoservice   ✔ And an instance of this service
exoservice   ✔ When receiving the "ping" command
exoservice   ✔ Then this service replies with a "pong" message
exoservice 
exoservice 1 scenario (1 passed)
exoservice 4 steps (4 passed)
exoservice 0m00.057s
  exo-test exoservice exited with code 0
  exo-test all services online
  exo-test 'exoservice' tests passed
  exo-test killing test containers
  exo-test Creating exoservice ... done
  exo-test 
  exo-test The EXOCOM_PORT variable is not set. Defaulting to a blank string.
  exo-test Removing exoservice ...
  exo-test Removing exoservice ... done
  exo-test Removing network tmp_default
  exo-test All tests passed
```