### PR TITLE
exo add: remove double colons from prompts

### DIFF
--- a/src/cmd/add.go
+++ b/src/cmd/add.go
@@ -41,7 +41,7 @@ var addCmd = &cobra.Command{
 		if len(templatesChoices) == 0 {
 			exitBecauseNoTemplates()
 		}
-		chosenTemplate := templatesChoices[prompt.Choose("Please choose a template:", templatesChoices)]
+		chosenTemplate := templatesChoices[prompt.Choose("Please choose a template", templatesChoices)]
 		if err != nil {
 			panic(err)
 		}

--- a/src/config/app_config_helpers.go
+++ b/src/config/app_config_helpers.go
@@ -50,7 +50,7 @@ func GetEnvironmentVariables(appBuiltDependencies map[string]AppDependency) map[
 // application.yml
 func UpdateAppConfig(appDir string, serviceRole string, appConfig types.AppConfig) error {
 	protectionLevels := []string{"public", "private"}
-	switch protectionLevels[prompt.Choose("Protection Level:", protectionLevels)] {
+	switch protectionLevels[prompt.Choose("Protection Level", protectionLevels)] {
 	case "public":
 		if appConfig.Services.Public == nil {
 			appConfig.Services.Public = make(map[string]types.ServiceData)


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #479

<!-- a short description of the change in addition to what is already mentioned in the issue above -->

<!-- tag a few reviewers -->
