### PR TITLE
Test cleanup bug

### DIFF
--- a/test_helpers/shared_feature_context.go
+++ b/test_helpers/shared_feature_context.go
@@ -51,15 +51,6 @@ func SharedFeatureContext(s *godog.Suite) {
 	})
 
 	s.AfterScenario(func(arg1 interface{}, arg2 error) {
-		if err := os.RemoveAll(appDir); err != nil {
-			panic(err)
-		}
-		if childCmdPlus != nil {
-			if err := childCmdPlus.Kill(); err != nil {
-				panic(err)
-			}
-			childCmdPlus = nil
-		}
 		dockerComposeDir := path.Join(appDir, "tmp")
 		hasDockerCompose, err := util.DoesFileExist(path.Join(dockerComposeDir, "docker-compose.yml"))
 		if err != nil {
@@ -69,6 +60,15 @@ func SharedFeatureContext(s *godog.Suite) {
 			if err := killTestContainers(dockerComposeDir); err != nil {
 				panic(err)
 			}
+		}
+		if err := os.RemoveAll(appDir); err != nil {
+			panic(err)
+		}
+		if childCmdPlus != nil {
+			if err := childCmdPlus.Kill(); err != nil {
+				panic(err)
+			}
+			childCmdPlus = nil
 		}
 	})
 

--- a/test_helpers/shared_feature_context.go
+++ b/test_helpers/shared_feature_context.go
@@ -51,6 +51,12 @@ func SharedFeatureContext(s *godog.Suite) {
 	})
 
 	s.AfterScenario(func(arg1 interface{}, arg2 error) {
+		if childCmdPlus != nil {
+			if err := childCmdPlus.Kill(); err != nil {
+				panic(err)
+			}
+			childCmdPlus = nil
+		}
 		dockerComposeDir := path.Join(appDir, "tmp")
 		hasDockerCompose, err := util.DoesFileExist(path.Join(dockerComposeDir, "docker-compose.yml"))
 		if err != nil {
@@ -63,12 +69,6 @@ func SharedFeatureContext(s *godog.Suite) {
 		}
 		if err := os.RemoveAll(appDir); err != nil {
 			panic(err)
-		}
-		if childCmdPlus != nil {
-			if err := childCmdPlus.Kill(); err != nil {
-				panic(err)
-			}
-			childCmdPlus = nil
 		}
 	})
 


### PR DESCRIPTION
We were removing the app directory before we could run `docker-compose down`, so containers weren't being cleaned up. Line 61 (in new file) was always returning false because there was no `tmp/docker-compose.yml` to run `docker-compose down` against.