### PR TITLE
exo run: update environment variables

### DIFF
--- a/src/application/initializer_test.go
+++ b/src/application/initializer_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Initializer", func() {
 		for _, serviceName := range internalServices {
 			environment := dockerCompose.Services[serviceName].Environment
 			Expect(environment["EXOCOM_HOST"]).To(Equal("exocom0.24.0"))
-			Expect(environment["EXOCOM_PORT"]).To(Equal("$EXOCOM_PORT"))
+			Expect(environment["EXOCOM_PORT"]).To(Equal("80"))
 		}
 
 		By("should generate a volume path for an external dependency that mounts a volume")

--- a/src/application/initializer_test.go
+++ b/src/application/initializer_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Initializer", func() {
 
 		By("should include the correct exocom environment variables")
 		environment := dockerCompose.Services["exocom0.24.0"].Environment
-		Expect(environment["PORT"]).To(Equal("$EXOCOM_PORT"))
+		Expect(environment["PORT"]).To(Equal("80"))
 		expectedServiceRoutes := []string{
 			`{"receives":["todo.create"],"role":"todo-service","sends":["todo.created"]}`,
 			`{"namespace":"mongo","receives":["mongo.list","mongo.create"],"role":"users-service","sends":["mongo.listed","mongo.created"]}`,

--- a/src/application/service_restarter.go
+++ b/src/application/service_restarter.go
@@ -13,7 +13,6 @@ type serviceRestarter struct {
 	ServiceName      string
 	ServiceDir       string
 	DockerComposeDir string
-	Env              []string
 	LogChannel       chan string
 	watcher          *fsnotify.Watcher
 }
@@ -54,7 +53,6 @@ func (s *serviceRestarter) restart(watcherErrChannel chan<- error) {
 		DockerComposeDir: s.DockerComposeDir,
 		ImageName:        s.ServiceName,
 		LogChannel:       s.LogChannel,
-		Env:              s.Env,
 	}
 	if err := compose.KillContainer(opts); err != nil {
 		watcherErrChannel <- errors.Wrap(err, fmt.Sprintf("Docker failed to kill container %s", s.ServiceName))

--- a/src/config/app_config_helpers.go
+++ b/src/config/app_config_helpers.go
@@ -34,18 +34,6 @@ func GetAppBuiltDependencies(appConfig types.AppConfig, appDir, homeDir string) 
 	return result
 }
 
-// GetEnvironmentVariables returns the environment variables of
-// all dependencies listed in appConfig
-func GetEnvironmentVariables(appBuiltDependencies map[string]AppDependency) map[string]string {
-	result := map[string]string{}
-	for _, builtDependency := range appBuiltDependencies {
-		for variable, value := range builtDependency.GetEnvVariables() {
-			result[variable] = value
-		}
-	}
-	return result
-}
-
 // UpdateAppConfig adds serviceRole to the appConfig object and updates
 // application.yml
 func UpdateAppConfig(appDir string, serviceRole string, appConfig types.AppConfig) error {

--- a/src/config/app_config_helpers_test.go
+++ b/src/config/app_config_helpers_test.go
@@ -48,16 +48,4 @@ var _ = Describe("App Config Helpers", func() {
 		})
 
 	})
-
-	var _ = Describe("GetEnvironmentVariables", func() {
-		It("should return the environment variables of all dependencies", func() {
-			appDir := path.Join("..", "..", "example-apps", "complex-setup-app")
-			appConfig, err := types.NewAppConfig(appDir)
-			Expect(err).NotTo(HaveOccurred())
-			builtDependencies := config.GetAppBuiltDependencies(appConfig, appDir, homeDir)
-			actual := config.GetEnvironmentVariables(builtDependencies)
-			expected := map[string]string{"EXOCOM_PORT": "80", "DB_NAME": "test-db"}
-			Expect(actual).To(Equal(expected))
-		})
-	})
 })

--- a/src/config/app_dependency.go
+++ b/src/config/app_dependency.go
@@ -1,15 +1,12 @@
 package config
 
-import (
-	"github.com/Originate/exosphere/src/types"
-)
+import "github.com/Originate/exosphere/src/types"
 
 // AppDependency contains methods that return config information about a dependency
 type AppDependency interface {
 	GetContainerName() string
 	GetDeploymentConfig() (map[string]string, error)
 	GetDockerConfig() (types.DockerConfig, error)
-	GetEnvVariables() map[string]string
 	GetOnlineText() string
 	GetServiceEnvVariables() map[string]string
 }

--- a/src/config/app_dependency_test.go
+++ b/src/config/app_dependency_test.go
@@ -49,16 +49,15 @@ var _ = Describe("AppDependency", func() {
 		})
 
 		var _ = Describe("GetDockerConfig", func() {
-			expectedServiceRoutes := []string{
-				`{"receives":["users.listed","users.created"],"role":"external-service","sends":["users.list","users.create"]}`,
-				`{"receives":["todo.create"],"role":"todo-service","sends":["todo.created"]}`,
-				`{"namespace":"mongo","receives":["mongo.list","mongo.create"],"role":"users-service","sends":["mongo.listed","mongo.created"]}`,
-				`{"receives":["todo.created"],"role":"html-server","sends":["todo.create"]}`,
-			}
-
 			It("should return the correct docker config for exocom", func() {
 				actual, err := exocom.GetDockerConfig()
 				Expect(err).NotTo(HaveOccurred())
+				expectedServiceRoutes := []string{
+					`{"receives":["users.listed","users.created"],"role":"external-service","sends":["users.list","users.create"]}`,
+					`{"receives":["todo.create"],"role":"todo-service","sends":["todo.created"]}`,
+					`{"namespace":"mongo","receives":["mongo.list","mongo.create"],"role":"users-service","sends":["mongo.listed","mongo.created"]}`,
+					`{"receives":["todo.created"],"role":"html-server","sends":["todo.create"]}`,
+				}
 				for _, serviceRoute := range expectedServiceRoutes {
 					Expect(strings.Contains(actual.Environment["SERVICE_ROUTES"], serviceRoute))
 				}

--- a/src/config/exocom_dependency.go
+++ b/src/config/exocom_dependency.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/Originate/exosphere/src/types"
 )
@@ -66,19 +65,10 @@ func (e *exocomDependency) GetDockerConfig() (types.DockerConfig, error) {
 		Image:         fmt.Sprintf("originate/exocom:%s", e.config.Version),
 		Environment: map[string]string{
 			"ROLE":           "exocom",
-			"PORT":           "$EXOCOM_PORT",
+			"PORT":           "80",
 			"SERVICE_ROUTES": serviceRoutes,
 		},
 	}, nil
-}
-
-// GetEnvVariables returns the environment variables
-func (e *exocomDependency) GetEnvVariables() map[string]string {
-	port := os.Getenv("EXOCOM_PORT")
-	if len(port) == 0 {
-		port = "80"
-	}
-	return map[string]string{"EXOCOM_PORT": port}
 }
 
 // GetOnlineText returns the online text for the exocom
@@ -91,7 +81,7 @@ func (e *exocomDependency) GetOnlineText() string {
 func (e *exocomDependency) GetServiceEnvVariables() map[string]string {
 	return map[string]string{
 		"EXOCOM_HOST": e.GetContainerName(),
-		"EXOCOM_PORT": "$EXOCOM_PORT",
+		"EXOCOM_PORT": "80",
 	}
 }
 

--- a/src/config/generic_dependency.go
+++ b/src/config/generic_dependency.go
@@ -38,6 +38,7 @@ func (g *genericDependency) GetDockerConfig() (types.DockerConfig, error) {
 		ContainerName: g.GetContainerName(),
 		Ports:         g.config.Config.Ports,
 		Volumes:       renderedVolumes,
+		Environment:   g.GetEnvVariables(),
 	}, nil
 }
 

--- a/src/config/generic_dependency.go
+++ b/src/config/generic_dependency.go
@@ -38,13 +38,8 @@ func (g *genericDependency) GetDockerConfig() (types.DockerConfig, error) {
 		ContainerName: g.GetContainerName(),
 		Ports:         g.config.Config.Ports,
 		Volumes:       renderedVolumes,
-		Environment:   g.GetEnvVariables(),
+		Environment:   g.config.Config.DependencyEnvironment,
 	}, nil
-}
-
-// GetEnvVariables returns the environment variables
-func (g *genericDependency) GetEnvVariables() map[string]string {
-	return g.config.Config.DependencyEnvironment
 }
 
 // GetOnlineText returns the online text

--- a/src/docker/composebuilder/index_test.go
+++ b/src/docker/composebuilder/index_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ComposeBuilder", func() {
 					Environment: map[string]string{
 						"ROLE":        "mongo",
 						"EXOCOM_HOST": "exocom0.24.0",
-						"EXOCOM_PORT": "$EXOCOM_PORT",
+						"EXOCOM_PORT": "80",
 						"MONGO":       "mongo",
 					},
 					DependsOn: []string{"exocom0.24.0", "mongo3.4.0"},


### PR DESCRIPTION
* make the exocom port hardcoded. There is no reason I can think of for anyone to override it since we are using docker images.
* put env variables into the docker compose file instead of using env variables passed to docker run