### PR TITLE
exo deploy: fix long service name requirement

### DIFF
--- a/src/terraform/modules/aws/alb/alb.tf
+++ b/src/terraform/modules/aws/alb/alb.tf
@@ -1,5 +1,5 @@
 resource "aws_alb" "alb" {
-  name            = "${substr(var.name, 0, 31)}"
+  name            = "${length(var.name) <= 32 ? var.name : substr(var.name, 0, 31)}"
   subnets         = ["${var.subnet_ids}"]
   security_groups = ["${var.security_groups}"]
   internal        = "${var.internal}"
@@ -16,7 +16,7 @@ resource "aws_alb" "alb" {
 }
 
 resource "aws_alb_target_group" "target_group" {
-  name     = "${substr(var.name, 0, 31)}"
+  name     = "${length(var.name) <= 32 ? var.name : substr(var.name, 0, 31)}"
   port     = 80
   protocol = "HTTP"
   vpc_id   = "${var.vpc_id}"


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #523

<!-- a short description of the change in addition to what is already mentioned in the issue above -->

<!-- tag a few reviewers -->
