### PR TITLE
Fix terraform bug

### DIFF
--- a/src/terraform/index_test.go
+++ b/src/terraform/index_test.go
@@ -61,6 +61,10 @@ provider "aws" {
   allowed_account_ids = ["12345"]
 }
 
+variable "key_name" {
+  default = ""
+}
+
 module "aws" {
   source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=fa599050"
 

--- a/src/terraform/templates/aws.tf
+++ b/src/terraform/templates/aws.tf
@@ -18,6 +18,10 @@ provider "aws" {
   allowed_account_ids = ["{{accountID}}"]
 }
 
+variable "key_name" {
+  default = ""
+}
+
 module "aws" {
   source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref={{terraformCommitHash}}"
 

--- a/src/terraform/templates/exocom.tf
+++ b/src/terraform/templates/exocom.tf
@@ -1,7 +1,3 @@
-variable "key_name" {
-  default = ""
-}
-
 module "exocom_cluster" {
   source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//custom//exocom//exocom-cluster?ref={{terraformCommitHash}}"
 


### PR DESCRIPTION
`key_name` needs to be a defined variable whether or not exocom is used in a project. This change ensures that the `key_name` block is always generated in `main.tf`