### PR TITLE
release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.1 (2017-09-25)
+
+#### New Features
+
+* `exo run` / `exo test`: add `--no-mount` flag to disable mounting
+
 ## 0.26.0 (2017-09-21)
 
 #### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 #### New Features
 
 * `exo run` / `exo test`: add `--no-mount` flag to disable mounting
-* `exo deploy`: RDS support in production for postgres and mysql engines
+* `exo deploy`
+  * RDS support in production for postgres and mysql engines
+  * Support for production dependencies listed only in `service.yml`
 
 ## 0.26.0 (2017-09-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### New Features
 
 * `exo run` / `exo test`: add `--no-mount` flag to disable mounting
+* `exo deploy`: RDS support in production for postgres and mysql engines
 
 ## 0.26.0 (2017-09-21)
 

--- a/features/tutorial.feature
+++ b/features/tutorial.feature
@@ -20,7 +20,7 @@ Feature: Following the tutorial
     # Printing the exosphere version
     ########################################
     When running "exo version" in my application directory
-    Then it prints "Exosphere v0.26.0" in the terminal
+    Then it prints "Exosphere v0.26.1" in the terminal
 
     ########################################
     # Setting up the application

--- a/features/version.feature
+++ b/features/version.feature
@@ -9,4 +9,4 @@ Feature: displaying the version
 
   Scenario: displaying the version
     When running "exo version" in the terminal
-    Then it prints "Exosphere v0.26.0" in the terminal
+    Then it prints "Exosphere v0.26.1" in the terminal

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -11,7 +11,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays the version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Exosphere v0.26.0")
+		fmt.Println("Exosphere v0.26.1")
 	},
 }
 

--- a/src/terraform/index.go
+++ b/src/terraform/index.go
@@ -11,7 +11,7 @@ import (
 
 // terraformModulesCommitHash is the git commit hash that reflects
 // which of the Terraform modules in Originate/exosphere we are using
-const terraformModulesCommitHash = "fa599050"
+const terraformModulesCommitHash = "16663974"
 
 // GenerateFile generates the main terraform file given application and service configuration
 func GenerateFile(deployConfig types.DeployConfig, imagesMap map[string]string) error {

--- a/src/terraform/index_test.go
+++ b/src/terraform/index_test.go
@@ -66,7 +66,7 @@ variable "key_name" {
 }
 
 module "aws" {
-	source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=16663974"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=16663974"
 
   name              = "example-app"
   env               = "production"

--- a/src/terraform/index_test.go
+++ b/src/terraform/index_test.go
@@ -66,7 +66,7 @@ variable "key_name" {
 }
 
 module "aws" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=fa599050"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=16663974"
 
   name              = "example-app"
   env               = "production"
@@ -142,7 +142,7 @@ module "aws" {
 }
 
 module "public-service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//public-service?ref=fa599050"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//public-service?ref=16663974"
 
   name = "public-service"
 
@@ -177,7 +177,7 @@ module "public-service" {
 }
 
 module "private-service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//private-service?ref=fa599050"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//private-service?ref=16663974"
 
   name = "private-service"
 
@@ -209,7 +209,7 @@ module "private-service" {
 }
 
 module "worker-service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//worker-service?ref=fa599050"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//worker-service?ref=16663974"
 
   name = "worker-service"
 
@@ -259,7 +259,7 @@ module "worker-service" {
 			Expect(err).To(BeNil())
 			expected := normalizeWhitespace(
 				`module "exocom_cluster" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-cluster?ref=fa599050"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-cluster?ref=16663974"
 
   availability_zones          = "${module.aws.availability_zones}"
   env                         = "production"
@@ -280,7 +280,7 @@ module "worker-service" {
 }
 
 module "exocom_service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-service?ref=fa599050"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-service?ref=16663974"
 
   cluster_id            = "${module.exocom_cluster.cluster_id}"
   cpu_units             = "128"


### PR DESCRIPTION
* The no-mount flag is the only change
* Missed updating the terraform hash in 0.25.1 and 0.26.0