### PR TITLE
Add profile field to backend block

### DIFF
--- a/src/terraform/index_test.go
+++ b/src/terraform/index_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Template builder", func() {
 		bucket         = "example-app-terraform"
 		key            = "dev/terraform.tfstate"
 		region         = "us-west-2"
+		profile        = "my-profile"
 		dynamodb_table = "TerraformLocks"
 	}
 }

--- a/src/terraform/templates/aws.tf
+++ b/src/terraform/templates/aws.tf
@@ -6,6 +6,7 @@ terraform {
     bucket         = "{{stateBucket}}"
     key            = "dev/terraform.tfstate"
     region         = "{{region}}"
+    profile        = "{{awsProfile}}"
     dynamodb_table = "{{lockTable}}"
   }
 }


### PR DESCRIPTION
Discovered this just now - profile needs to be passed into the backend block so `terraform init` can use the proper credentials.