### PR TITLE
fix passed in env on docker

### DIFF
--- a/src/docker/compose/index.go
+++ b/src/docker/compose/index.go
@@ -1,6 +1,8 @@
 package compose
 
 import (
+	"os"
+
 	"github.com/Originate/exosphere/src/util"
 	execplus "github.com/Originate/go-execplus"
 )
@@ -19,7 +21,7 @@ func CreateNewContainer(opts ImageOptions) error {
 func KillAllContainers(opts BaseOptions) (*execplus.CmdPlus, error) {
 	cmdPlus := execplus.NewCmdPlus("docker-compose", "down")
 	cmdPlus.SetDir(opts.DockerComposeDir)
-	cmdPlus.SetEnv(opts.Env)
+	cmdPlus.SetEnv(append(opts.Env, os.Environ()...))
 	util.ConnectLogChannel(cmdPlus, opts.LogChannel)
 	return cmdPlus, cmdPlus.Start()
 }
@@ -38,7 +40,7 @@ func PullAllImages(opts BaseOptions) error {
 func RunImages(opts ImagesOptions) (*execplus.CmdPlus, error) {
 	cmdPlus := execplus.NewCmdPlus(append([]string{"docker-compose", "up"}, opts.ImageNames...)...)
 	cmdPlus.SetDir(opts.DockerComposeDir)
-	cmdPlus.SetEnv(opts.Env)
+	cmdPlus.SetEnv(append(opts.Env, os.Environ()...))
 	util.ConnectLogChannel(cmdPlus, opts.LogChannel)
 	return cmdPlus, cmdPlus.Start()
 }


### PR DESCRIPTION
<!-- mention the issue this PR addresses -->
resolves #582

This popped up when added the COMPOSE_PROJECT_NAME env variable so env was no longer empty in which case it would pass through the `os.Envrion`. I'm going to update go-execplus to have `AppendEnv` instead of `SetEnv` since this is the more common use case. 