### PR TITLE
logger: cleanup calls

### DIFF
--- a/src/application/deployer.go
+++ b/src/application/deployer.go
@@ -24,7 +24,7 @@ func StartDeploy(deployConfig types.DeployConfig) error {
 		return err
 	}
 
-	deployConfig.Logger.Log(fmt.Sprintf("Building %s %s...\n\n", deployConfig.AppConfig.Name, deployConfig.AppConfig.Version))
+	deployConfig.Logger.Log(fmt.Sprintf("Building %s %s...", deployConfig.AppConfig.Name, deployConfig.AppConfig.Version))
 	initializer, err := NewInitializer(
 		deployConfig.AppConfig,
 		deployConfig.Logger,

--- a/src/aws/ecr_helpers.go
+++ b/src/aws/ecr_helpers.go
@@ -31,7 +31,7 @@ func PushImages(deployConfig types.DeployConfig, dockerComposePath string) (map[
 		return nil, err
 	}
 	for serviceName, imageName := range imagesMap {
-		deployConfig.Logger.Log(fmt.Sprintf("Pushing image for: %s...\n\n", serviceName))
+		deployConfig.Logger.Log(fmt.Sprintf("Pushing image for: %s...", serviceName))
 		taggedImage, err := tagAndPushImage(deployConfig, serviceName, imageName)
 		if err != nil {
 			return nil, err

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -51,7 +51,7 @@ var runCmd = &cobra.Command{
 		} else if noMountFlag {
 			buildMode = composebuilder.BuildModeLocalDevelopmentNoMount
 		}
-		logger.Log(fmt.Sprintf("Setting up %s %s\n\n", appConfig.Name, appConfig.Version))
+		logger.Log(fmt.Sprintf("Setting up %s %s", appConfig.Name, appConfig.Version))
 		initializer, err := application.NewInitializer(
 			appConfig,
 			logger,
@@ -69,7 +69,7 @@ var runCmd = &cobra.Command{
 		}
 		logger.Log("setup complete")
 
-		logger.Log(fmt.Sprintf("Running %s %s\n\n", appConfig.Name, appConfig.Version))
+		logger.Log(fmt.Sprintf("Running %s %s", appConfig.Name, appConfig.Version))
 		runner, err := application.NewRunner(appConfig, logger, appDir, homeDir, dockerComposeProjectName)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Leading and trailing whitespace is removed from the text, thus these newlines weren't doing anything.