### PR TITLE
exo template test: no mount

### DIFF
--- a/example-templates/fail-if-mounted/project.json
+++ b/example-templates/fail-if-mounted/project.json
@@ -1,0 +1,6 @@
+{
+  "serviceRole": "ping-service",
+  "serviceType": "",
+  "description": "",
+  "author": ""
+}

--- a/example-templates/fail-if-mounted/template/{{serviceRole}}/Dockerfile.dev
+++ b/example-templates/fail-if-mounted/template/{{serviceRole}}/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM alpine
+RUN echo "#!/usr/bin/env true" > /mnt/test
+RUN chmod +x /mnt/test

--- a/example-templates/fail-if-mounted/template/{{serviceRole}}/Dockerfile.prod
+++ b/example-templates/fail-if-mounted/template/{{serviceRole}}/Dockerfile.prod
@@ -1,0 +1,2 @@
+FROM busybox:latest
+COPY . .

--- a/example-templates/fail-if-mounted/template/{{serviceRole}}/service.yml
+++ b/example-templates/fail-if-mounted/template/{{serviceRole}}/service.yml
@@ -1,0 +1,11 @@
+type: {{serviceType}}
+description: {{description}}
+author: {{author}}
+
+startup:
+  online-text: nothing to run
+
+development:
+  scripts:
+    run: /mnt/test
+    test: /mnt/test

--- a/features/template/test_template/success.feature
+++ b/features/template/test_template/success.feature
@@ -25,3 +25,8 @@ Feature: test templates
     Given I am in the root directory of the "good" example template
     When starting "exo template test" in my template directory
     Then it exits with code 0
+
+  Scenario: does not mount
+    Given I am in the root directory of the "fail-if-mounted" example template
+    When starting "exo template test" in my template directory
+    Then it exits with code 0

--- a/src/template/index.go
+++ b/src/template/index.go
@@ -183,7 +183,7 @@ func Run(templateDir, resultDir string) error {
 // RunTests (used by exo template test) runs exo-test in appDir and
 // returns whether or not the tests pass and the output of running the tests
 func RunTests(appDir string, outputWriter io.Writer) error {
-	cmd := execplus.NewCmdPlus("exo", "test")
+	cmd := execplus.NewCmdPlus("exo", "test", "--no-mount")
 	cmd.SetDir(appDir)
 	go sendCmdOutputToWriter(cmd, outputWriter)
 	return cmd.Run()


### PR DESCRIPTION
Updating `exo template test` to not mount. There is no need to mount and this was preventing me from setting up CI on the templates.