### PR TITLE
Remove terraform ref from tests

### DIFF
--- a/bin/pre-release
+++ b/bin/pre-release
@@ -2,7 +2,7 @@
 
 hash=$(git log --format="%h" -n 1 src/terraform/modules/)
 
-if [ -z "$(grep "$hash" src/terraform/index.go)" ]; then
+if [ -z "$(grep "$hash" src/cmd/deploy.go)" ]; then
   echo "Terraform module hash needs to be updated to $hash"
   exit 1
 fi

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -58,6 +58,9 @@ var deployCmd = &cobra.Command{
 			TerraformDir: terraformDir,
 			SecretsPath:  filepath.Join(terraformDir, "secrets.tfvars"),
 			AwsConfig:    awsConfig,
+
+			// git commit hash of the Terraform modules in Originate/exosphere we are using
+			TerraformModulesRef: "1bb2c93b",
 		}
 
 		err = application.StartDeploy(deployConfig)

--- a/src/terraform/index_test.go
+++ b/src/terraform/index_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Template builder", func() {
 				Region:               "us-west-2",
 				AccountID:            "12345",
 			},
+			TerraformModulesRef: "TERRAFORM_MODULES_REF",
 		}
 
 		It("should generate an AWS module only", func() {
@@ -65,7 +66,7 @@ variable "key_name" {
 }
 
 module "aws" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=1bb2c93b"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws?ref=TERRAFORM_MODULES_REF"
 
   name              = "example-app"
   env               = "production"
@@ -121,6 +122,7 @@ module "aws" {
 			AwsConfig: types.AwsConfig{
 				SslCertificateArn: "sslcert123",
 			},
+			TerraformModulesRef: "TERRAFORM_MODULES_REF",
 		}
 
 		BeforeEach(func() {
@@ -138,7 +140,7 @@ module "aws" {
 variable "public-service_docker_image" {}
 
 module "public-service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//public-service?ref=1bb2c93b"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//public-service?ref=TERRAFORM_MODULES_REF"
 
   name = "public-service"
 
@@ -175,7 +177,7 @@ module "public-service" {
 variable "private-service_docker_image" {}
 
 module "private-service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//private-service?ref=1bb2c93b"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//private-service?ref=TERRAFORM_MODULES_REF"
 
   name = "private-service"
 
@@ -209,7 +211,7 @@ module "private-service" {
 variable "worker-service_docker_image" {}
 
 module "worker-service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//worker-service?ref=1bb2c93b"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//worker-service?ref=TERRAFORM_MODULES_REF"
 
   name = "worker-service"
 
@@ -246,10 +248,11 @@ module "worker-service" {
 			Expect(err).NotTo(HaveOccurred())
 
 			deployConfig := types.DeployConfig{
-				AppConfig:      appConfig,
-				ServiceConfigs: serviceConfigs,
-				AppDir:         appDir,
-				HomeDir:        homeDir,
+				AppConfig:           appConfig,
+				ServiceConfigs:      serviceConfigs,
+				AppDir:              appDir,
+				HomeDir:             homeDir,
+				TerraformModulesRef: "TERRAFORM_MODULES_REF",
 			}
 			imagesMap := map[string]string{
 				"exocom": "originate/exocom:0.0.1",
@@ -259,7 +262,7 @@ module "worker-service" {
 			Expect(err).To(BeNil())
 			expected := normalizeWhitespace(
 				`module "exocom_cluster" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-cluster?ref=1bb2c93b"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-cluster?ref=TERRAFORM_MODULES_REF"
 
   availability_zones          = "${module.aws.availability_zones}"
   env                         = "production"
@@ -280,7 +283,7 @@ module "worker-service" {
 }
 
 module "exocom_service" {
-  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-service?ref=1bb2c93b"
+  source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//exocom//exocom-service?ref=TERRAFORM_MODULES_REF"
 
   cluster_id            = "${module.exocom_cluster.cluster_id}"
   cpu_units             = "128"
@@ -309,9 +312,10 @@ EOF
 			Expect(err).NotTo(HaveOccurred())
 
 			deployConfig := types.DeployConfig{
-				AppConfig:      appConfig,
-				AppDir:         appDir,
-				ServiceConfigs: serviceConfigs,
+				AppConfig:           appConfig,
+				AppDir:              appDir,
+				ServiceConfigs:      serviceConfigs,
+				TerraformModulesRef: "TERRAFORM_MODULES_REF",
 			}
 			imagesMap := map[string]string{
 				"postgres": "postgres:9.6.4",
@@ -323,7 +327,7 @@ EOF
 			By("generating rds modules for application dependencies", func() {
 				expected := normalizeWhitespace(
 					`module "my-db_rds_instance" {
-	source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//rds?ref=1bb2c93b"
+	source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//rds?ref=TERRAFORM_MODULES_REF"
 
   allocated_storage       = 10
   ecs_security_group      = "${module.aws.ecs_cluster_security_group}"
@@ -345,7 +349,7 @@ EOF
 			By("should generate rds modules for service dependencies", func() {
 				expected := normalizeWhitespace(
 					`module "my-sql-db_rds_instance" {
-	source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//rds?ref=1bb2c93b"
+	source = "git@github.com:Originate/exosphere.git//src//terraform//modules//aws//dependencies//rds?ref=TERRAFORM_MODULES_REF"
 
   allocated_storage       = 10
   ecs_security_group      = "${module.aws.ecs_cluster_security_group}"

--- a/src/types/deploy_config.go
+++ b/src/types/deploy_config.go
@@ -17,6 +17,7 @@ type DeployConfig struct {
 	TerraformDir             string
 	SecretsPath              string
 	AwsConfig                AwsConfig
+	TerraformModulesRef      string
 }
 
 // GetSortedServiceNames returns the service names sorted alphabetically


### PR DESCRIPTION
We shouldn't need to update test files anytime we update the terraform hash.

Also I think we eventually might want to make this user configurable or at least generate a `terraform/ref.lock` to make sure we don't go swapping out terraform modules out from under the user for applications that need extremely stable deployments.

For right now I think it's good that we can update since we're still iterating quickly, but when we land on a more stable API we should semantically version this or something