### PR TITLE
Remove version from feature tests

### DIFF
--- a/features/tutorial.feature
+++ b/features/tutorial.feature
@@ -20,7 +20,7 @@ Feature: Following the tutorial
     # Printing the exosphere version
     ########################################
     When running "exo version" in my application directory
-    Then it prints "Exosphere v0.26.3" in the terminal
+    Then it prints the current version in the terminal
 
     ########################################
     # Setting up the application

--- a/features/version.feature
+++ b/features/version.feature
@@ -9,4 +9,4 @@ Feature: displaying the version
 
   Scenario: displaying the version
     When running "exo version" in the terminal
-    Then it prints "Exosphere v0.26.3" in the terminal
+    Then it prints the current version in the terminal

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/Originate/exosphere/src"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +12,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays the version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Exosphere v0.26.3")
+		fmt.Printf("Exosphere v%s\n", src.Version)
 	},
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -1,0 +1,3 @@
+package src
+
+const Version = "0.26.3"

--- a/src/version.go
+++ b/src/version.go
@@ -1,3 +1,4 @@
 package src
 
+// Version exports the current Exosphere Version
 const Version = "0.26.3"

--- a/test_helpers/shared_feature_context.go
+++ b/test_helpers/shared_feature_context.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DATA-DOG/godog"
 	"github.com/DATA-DOG/godog/gherkin"
+	"github.com/Originate/exosphere/src"
 	"github.com/Originate/exosphere/src/util"
 	execplus "github.com/Originate/go-execplus"
 	"github.com/pkg/errors"
@@ -214,6 +215,14 @@ func SharedFeatureContext(s *godog.Suite) {
 	// Verifying output
 
 	s.Step(`^it prints "([^"]*)" in the terminal$`, func(text string) error {
+		if childCmdPlus != nil {
+			return childCmdPlus.WaitForText(text, time.Minute)
+		}
+		return validateTextContains(childOutput, text)
+	})
+
+	s.Step(`^it prints the current version in the terminal$`, func() error {
+		text := fmt.Sprintf("Exosphere v%s", src.Version)
 		if childCmdPlus != nil {
 			return childCmdPlus.WaitForText(text, time.Minute)
 		}


### PR DESCRIPTION
I don't think we should be forced to update our feature tests every time we bump a version