### PR TITLE
exo clean: fix

### DIFF
--- a/features/clean.feature
+++ b/features/clean.feature
@@ -13,6 +13,7 @@ Feature: cleaning dangling Docker images
   Background:
     Given I am in the root directory of the "clean-containers" example application
 
+
   Scenario: cleaning a machine with both dangling and non-dangling Doker images
     Given my machine has both dangling and non-dangling Docker images and volumes
     When running "exo clean" in my application directory
@@ -22,11 +23,16 @@ Feature: cleaning dangling Docker images
     And it does not have dangling images
     And it does not have dangling volumes
 
+
   Scenario: cleaning a machine with running application and test containers
     Given my machine has running application and test containers
     And my machine has running third party containers
     When running "exo clean" in my application directory
+    Then it prints "Stopping app-test-container" in the terminal
+    Then it prints "Removing app-test-container" in the terminal
     Then it prints "removed application containers" in the terminal
+    Then it prints "Stopping service-test-container" in the terminal
+    Then it prints "Removing service-test-container" in the terminal
     Then it prints "removed test containers" in the terminal
     And it removes application and test containers
     And it does not stop any third party containers
@@ -36,7 +42,9 @@ Feature: cleaning dangling Docker images
     Given my machine has stopped application and test containers
     And my machine has running third party containers
     When running "exo clean" in my application directory
+    Then it prints "Removing app-test-container" in the terminal
     Then it prints "removed application containers" in the terminal
+    Then it prints "Removing service-test-container" in the terminal
     Then it prints "removed test containers" in the terminal
     And it removes application and test containers
     And it does not stop any third party containers

--- a/src/application/clean.go
+++ b/src/application/clean.go
@@ -40,7 +40,7 @@ func killIfExists(dockerComposeFile, composeProjectName string, logger *util.Log
 		return err
 	}
 	if exists {
-		_, err = compose.KillAllContainers(compose.BaseOptions{
+		err = compose.KillAllContainers(compose.BaseOptions{
 			DockerComposeDir: path.Dir(dockerComposeFile),
 			Logger:           logger,
 			Env:              []string{fmt.Sprintf("COMPOSE_PROJECT_NAME=%s", composeProjectName)},

--- a/src/application/runner.go
+++ b/src/application/runner.go
@@ -102,17 +102,13 @@ func (r *Runner) Shutdown(shutdownConfig types.ShutdownConfig) error {
 	} else {
 		r.logger.Log(shutdownConfig.CloseMessage)
 	}
-	process, err := compose.KillAllContainers(compose.BaseOptions{
+	err := compose.KillAllContainers(compose.BaseOptions{
 		DockerComposeDir: r.DockerComposeDir,
 		Logger:           r.logger,
 		Env:              []string{fmt.Sprintf("COMPOSE_PROJECT_NAME=%s", r.DockerComposeProjectName)},
 	})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed to shutdown the app\nOutput: %s\nError: %s\n", process.GetOutput(), err))
-	}
-	err = process.Wait()
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed to shutdown the app\nOutput: %s\nError: %s\n", process.GetOutput(), err))
+		return errors.Wrap(err, "Failed to shutdown the app")
 	}
 	return nil
 }

--- a/src/application/service_tester.go
+++ b/src/application/service_tester.go
@@ -125,7 +125,7 @@ func (s *ServiceTester) runTests() (int, error) {
 }
 
 func (s *ServiceTester) setup() error {
-	dockerComposeDir := path.Join(s.AppDir, s.ServiceDir, "tests", "tmp")
+	dockerComposeDir := path.Join(s.ServiceDir, "tests", "tmp")
 	if err := s.Initializer.renderDockerCompose(dockerComposeDir); err != nil {
 		return err
 	}

--- a/src/docker/compose/index.go
+++ b/src/docker/compose/index.go
@@ -16,12 +16,8 @@ func CreateNewContainer(opts ImageOptions) error {
 }
 
 // KillAllContainers kills all the containers
-func KillAllContainers(opts BaseOptions) (*execplus.CmdPlus, error) {
-	cmdPlus := execplus.NewCmdPlus("docker-compose", "down")
-	cmdPlus.SetDir(opts.DockerComposeDir)
-	cmdPlus.AppendEnv(opts.Env)
-	util.ConnectLogChannel(cmdPlus, opts.Logger)
-	return cmdPlus, cmdPlus.Start()
+func KillAllContainers(opts BaseOptions) error {
+	return util.RunAndLog(opts.DockerComposeDir, opts.Env, opts.Logger, "docker-compose", "down")
 }
 
 // KillContainer kills the docker container of the given service

--- a/test_helpers/index.go
+++ b/test_helpers/index.go
@@ -77,17 +77,13 @@ func createEmptyApp(appName, cwd string) (string, error) {
 func killTestContainers(dockerComposeDir, appDir string) error {
 	dockerComposeProjectName := composebuilder.GetDockerComposeProjectName(appDir)
 	mockLogger := util.NewLogger([]string{}, []string{}, "", ioutil.Discard)
-	cleanProcess, err := compose.KillAllContainers(compose.BaseOptions{
+	err := compose.KillAllContainers(compose.BaseOptions{
 		DockerComposeDir: dockerComposeDir,
 		Logger:           mockLogger,
 		Env:              []string{fmt.Sprintf("COMPOSE_PROJECT_NAME=%s", dockerComposeProjectName)},
 	})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Output:%s", cleanProcess.GetOutput()))
-	}
-	err = cleanProcess.Wait()
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Output:%s", cleanProcess.GetOutput()))
+		return errors.Wrap(err, "Failed to kill test containers")
 	}
 	return nil
 }


### PR DESCRIPTION
exo clean was not working properly. Found that we were not waiting for the kill to finish as `KillTestContainers` was only starting the kill process instead of taking it to conclusion.

Don't think we were testing this properly