### PR TITLE
Fix os stat bug

### DIFF
--- a/src/terraform/template_builder.go
+++ b/src/terraform/template_builder.go
@@ -49,11 +49,15 @@ func getTemplate(template string) (string, error) {
 // ReadTerraformFile reads the contents of the main terraform file
 func ReadTerraformFile(deployConfig types.DeployConfig) ([]byte, error) {
 	terraformFilePath := filepath.Join(deployConfig.TerraformDir, terraformFile)
-	var err error
-	if _, err = os.Stat(terraformFilePath); !os.IsNotExist(err) {
+	_, err := os.Stat(terraformFilePath)
+	switch {
+	case os.IsExist(err):
 		return ioutil.ReadFile(terraformFilePath)
+	case os.IsNotExist(err):
+		return []byte{}, nil
+	default:
+		return []byte{}, err
 	}
-	return []byte{}, err
 }
 
 // CheckTerraformFile makes sure that the generated terraform file hasn't changed from the previous one

--- a/src/terraform/template_builder.go
+++ b/src/terraform/template_builder.go
@@ -49,13 +49,10 @@ func getTemplate(template string) (string, error) {
 // ReadTerraformFile reads the contents of the main terraform file
 func ReadTerraformFile(deployConfig types.DeployConfig) ([]byte, error) {
 	terraformFilePath := filepath.Join(deployConfig.TerraformDir, terraformFile)
-	_, err := os.Stat(terraformFilePath)
-	switch {
-	case os.IsExist(err):
+	fileExists, err := os.Stat(terraformFilePath)
+	if fileExists {
 		return ioutil.ReadFile(terraformFilePath)
-	case os.IsNotExist(err):
-		return []byte{}, nil
-	default:
+	} else {
 		return []byte{}, err
 	}
 }

--- a/src/terraform/template_builder.go
+++ b/src/terraform/template_builder.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/Originate/exosphere/src/types"
+	"github.com/Originate/exosphere/src/util"
 	"github.com/hoisie/mustache"
 	"github.com/pkg/errors"
 )
@@ -49,7 +50,7 @@ func getTemplate(template string) (string, error) {
 // ReadTerraformFile reads the contents of the main terraform file
 func ReadTerraformFile(deployConfig types.DeployConfig) ([]byte, error) {
 	terraformFilePath := filepath.Join(deployConfig.TerraformDir, terraformFile)
-	fileExists, err := os.Stat(terraformFilePath)
+	fileExists, err := util.DoesFileExist(terraformFilePath)
 	if fileExists {
 		return ioutil.ReadFile(terraformFilePath)
 	}

--- a/src/terraform/template_builder.go
+++ b/src/terraform/template_builder.go
@@ -52,9 +52,8 @@ func ReadTerraformFile(deployConfig types.DeployConfig) ([]byte, error) {
 	fileExists, err := os.Stat(terraformFilePath)
 	if fileExists {
 		return ioutil.ReadFile(terraformFilePath)
-	} else {
-		return []byte{}, err
 	}
+	return []byte{}, err
 }
 
 // CheckTerraformFile makes sure that the generated terraform file hasn't changed from the previous one


### PR DESCRIPTION
This was throwing an error when `main.tf` did not exist, when we really just want to return an empty byte array