### PR TITLE
S3 Bucket cleanup

### DIFF
--- a/src/cmd/shared.go
+++ b/src/cmd/shared.go
@@ -54,8 +54,8 @@ func getAwsConfig(profile string) (types.AwsConfig, error) {
 		SslCertificateArn:    appConfig.Production.SslCertificateArn,
 		Profile:              profile,
 		CredentialsFile:      path.Join(homeDir, ".aws", "credentials"),
-		SecretsBucket:        fmt.Sprintf("%s-terraform-secrets", appConfig.Name),
-		TerraformStateBucket: fmt.Sprintf("%s-terraform", appConfig.Name),
+		SecretsBucket:        fmt.Sprintf("%s-%s-terraform-secrets", appConfig.Production.AccountID, appConfig.Name),
+		TerraformStateBucket: fmt.Sprintf("%s-%s-terraform", appConfig.Production.AccountID, appConfig.Name),
 		TerraformLockTable:   "TerraformLocks",
 	}, nil
 }

--- a/src/terraform/index_test.go
+++ b/src/terraform/index_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Template builder", func() {
 
 	backend "s3" {
 		bucket         = "example-app-terraform"
-		key            = "dev/terraform.tfstate"
+		key            = "terraform.tfstate"
 		region         = "us-west-2"
 		dynamodb_table = "TerraformLocks"
 	}

--- a/src/terraform/templates/aws.tf
+++ b/src/terraform/templates/aws.tf
@@ -7,7 +7,7 @@ terraform {
 
   backend "s3" {
     bucket         = "{{stateBucket}}"
-    key            = "dev/terraform.tfstate"
+    key            = "terraform.tfstate"
     region         = "{{region}}"
     dynamodb_table = "{{lockTable}}"
   }


### PR DESCRIPTION
Resolves: https://github.com/Originate/exosphere/issues/628

Also removes unnecessary `dev` key in front of file key. I think that will become confusing as we start deploying to multiple environments.

Something to note: if we update existing projects (EDX) to use this, we might have to tear down their existing infrastructure before re-deploying, since we're putting`terraform.tfstate` in a whole new location. Alternatively we can try copying `edx-terraform/dev/terraform.tfstate` to `#{account-id}-edx-terraform/terraform.tfstate`. Same goes for application secrets.