### PR TITLE
exo deploy: load aws credentials from env variables

### DIFF
--- a/src/aws/index.go
+++ b/src/aws/index.go
@@ -145,7 +145,12 @@ func getEcrAuth(ecrClient *ecr.ECR) (string, string, error) {
 
 func createAwsConfig(awsConfig types.AwsConfig) *aws.Config {
 	return &aws.Config{
-		Region:      aws.String(awsConfig.Region),
-		Credentials: credentials.NewSharedCredentials(awsConfig.CredentialsFile, awsConfig.Profile),
+		Region: aws.String(awsConfig.Region),
+		Credentials: credentials.NewCredentials(&credentials.ChainProvider{
+			Providers: []credentials.Provider{
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{Profile: awsConfig.Profile},
+			},
+		}),
 	}
 }

--- a/src/cmd/shared.go
+++ b/src/cmd/shared.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 
 	"github.com/Originate/exosphere/src/aws"
 	"github.com/Originate/exosphere/src/docker/composebuilder"
 	"github.com/Originate/exosphere/src/types"
-	"github.com/Originate/exosphere/src/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -44,16 +42,11 @@ func getAwsConfig(profile string) (types.AwsConfig, error) {
 	if err != nil {
 		return types.AwsConfig{}, err
 	}
-	homeDir, err := util.GetHomeDirectory()
-	if err != nil {
-		return types.AwsConfig{}, fmt.Errorf("Cannot get home directory: %s", err)
-	}
 	return types.AwsConfig{
 		Region:               appConfig.Production.Region,
 		AccountID:            appConfig.Production.AccountID,
 		SslCertificateArn:    appConfig.Production.SslCertificateArn,
 		Profile:              profile,
-		CredentialsFile:      path.Join(homeDir, ".aws", "credentials"),
 		SecretsBucket:        fmt.Sprintf("%s-%s-terraform-secrets", appConfig.Production.AccountID, appConfig.Name),
 		TerraformStateBucket: fmt.Sprintf("%s-%s-terraform", appConfig.Production.AccountID, appConfig.Name),
 		TerraformLockTable:   "TerraformLocks",

--- a/src/types/aws_config.go
+++ b/src/types/aws_config.go
@@ -6,7 +6,6 @@ type AwsConfig struct {
 	AccountID            string
 	SslCertificateArn    string
 	Profile              string
-	CredentialsFile      string
 	SecretsBucket        string
 	TerraformStateBucket string
 	TerraformLockTable   string


### PR DESCRIPTION
Needed for CI. The credentials file defaults to `~/.aws/credentials` 

Copied some of the code for the default credentials chain: https://github.com/aws/aws-sdk-go/blob/4a5fb7e221f1be0cb59b4cd4a50b56669b1d099b/aws/defaults/defaults.go#L90
