### PR TITLE
Release 0.28.1 and update terraform hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.28.1 (2017-10-18)
+
+#### New Features
+* `exo-deploy`
+  * pass exocom service routes as a variable to main.tf file
+  * don't build images that won't be pushed to ECR
+
+#### Bug fixes
+
+* `exo test`: fix bug that required service role and service directory be the same name
+* `exo-deploy`: fix Terraform issue of ECS services being spun up before target groups were created
+
 ## 0.28.0 (2017-10-10)
 
 #### BREAKING CHANGES

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -62,7 +62,7 @@ var deployCmd = &cobra.Command{
 			DeployServicesOnly: deployServicesFlag,
 
 			// git commit hash of the Terraform modules in Originate/exosphere we are using
-			TerraformModulesRef: "d5c193c5",
+			TerraformModulesRef: "01891552",
 		}
 
 		err = deployer.StartDeploy(deployConfig)

--- a/src/version.go
+++ b/src/version.go
@@ -1,4 +1,4 @@
 package src
 
 // Version exports the current Exosphere Version
-const Version = "0.28.0"
+const Version = "0.28.1"


### PR DESCRIPTION
Take 2 of releasing 0.28.1 (forgot to update terraform hash in take 1). I merged the changes from https://github.com/Originate/exosphere/pull/688 into master but I never tagged the release/pushed those tags, so I just reverted the commit. Will ship/do a proper release once this branch is green.