### PR TITLE
exo-deploy: tag images before pushing

### DIFF
--- a/src/application/deployer/push_image.go
+++ b/src/application/deployer/push_image.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Originate/exosphere/src/aws"
 	"github.com/Originate/exosphere/src/docker/compose"
+	"github.com/Originate/exosphere/src/docker/tools"
 )
 
 // PushImage pushes a single service/dependency image to ECR, building or pulling if needed
@@ -21,6 +22,10 @@ func PushImage(options PushImageOptions) (string, error) {
 	}
 	if needsPush {
 		err := buildOrPullImage(options)
+		if err != nil {
+			return "", err
+		}
+		err = tools.TagImage(options.ImageName, repositoryHelper.GetTaggedImageName())
 		if err != nil {
 			return "", err
 		}

--- a/src/docker/tools/index.go
+++ b/src/docker/tools/index.go
@@ -108,9 +108,13 @@ func RunInDockerImage(imageName, command string) (string, error) {
 }
 
 // TagImage tags a docker image srcImage as targetImage
-func TagImage(c *client.Client, srcImage, targetImage string) error {
+func TagImage(srcImage, targetImage string) error {
+	dockerClient, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
-	return c.ImageTag(ctx, srcImage, targetImage)
+	return dockerClient.ImageTag(ctx, srcImage, targetImage)
 }
 
 // PushImage pushes image with imageName to the registry given an encoded auth object


### PR DESCRIPTION
Seems like we missed a step in the exo-deploy refactor. Everything else seems to work