### PR TITLE
Name roles and instance profiles the same

### DIFF
--- a/src/terraform/modules/aws/ecs-cluster/iam.tf
+++ b/src/terraform/modules/aws/ecs-cluster/iam.tf
@@ -63,7 +63,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "ecs_instance" {
-  name = "${var.name}-ecs-instance-profile"
+  name = "${var.name}-ecs-instance-role"
   path = "/"
   role = "${aws_iam_role.ecs_instance.name}"
 }
@@ -91,7 +91,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "ecs_service" {
-  name = "${var.name}-ecs-service-role-policy"
+  name = "${var.name}-ecs-service-role"
   role = "${aws_iam_role.ecs_service.id}"
 
   policy = <<EOF


### PR DESCRIPTION
According to [this](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_delete.html) if we name roles and instance-profiles the same they should automatically be grouped and the instance profile will be automatically deleted when the role is deleted in AWS console.

This will fix the need to manually use the AWS CLI to delete the instance profile when `terraform destroy` is throwing a fit