### PR TITLE
simplify dependency logic

### DIFF
--- a/example-apps/external-dependency/application.yml
+++ b/example-apps/external-dependency/application.yml
@@ -7,13 +7,6 @@ development:
   dependencies:
     - name: exocom
       version: 0.26.1
-    - name: 'mongo'
-      version: '3.4.0'
-      config:
-        volumes:
-          - '{{EXO_DATA_PATH}}:/data/db'
-        ports:
-          - '27017:27017'
 
 services:
   public:

--- a/example-apps/external-dependency/mongo/service.yml
+++ b/example-apps/external-dependency/mongo/service.yml
@@ -9,6 +9,3 @@ messages:
 development:
   scripts:
     run: node server.js
-  dependencies:
-    - name: 'mongo'
-      version: '3.4.0'

--- a/example-apps/external-dependency/mongo/service.yml
+++ b/example-apps/external-dependency/mongo/service.yml
@@ -7,5 +7,13 @@ messages:
   receives:
 
 development:
+  dependencies:
+    - name: 'mongo'
+      version: '3.4.0'
+      config:
+        volumes:
+          - '{{EXO_DATA_PATH}}:/data/db'
+        ports:
+          - '27017:27017'
   scripts:
     run: node server.js

--- a/example-apps/rds/my-sql-service/service.yml
+++ b/example-apps/rds/my-sql-service/service.yml
@@ -2,6 +2,23 @@ type: my-sql
 description: for testing generation of Terraform files
 author: exospheredev
 
+production:
+  dependencies:
+    - name: mysql
+      version: 5.6.17
+      config:
+        rds:
+          allocated-storage: 10
+          instance-class: db.t1.micro
+          db-name: my-sql-db
+          username: originate-user
+          password-secret-name: MYSQL_PASSWORD
+          storage-type: gp2
+          service-env-var-names:
+            db-name: DATABASE_NAME
+            username: DATABASE_USERNAME
+            password: DATABASE_PASSWORD
+
 messages:
   sends:
   receives:

--- a/example-apps/rds/my-sql-service/service.yml
+++ b/example-apps/rds/my-sql-service/service.yml
@@ -2,23 +2,6 @@ type: my-sql
 description: for testing generation of Terraform files
 author: exospheredev
 
-production:
-  dependencies:
-    - name: mysql
-      version: 5.6.17
-      config:
-        rds:
-          allocated-storage: 10
-          instance-class: db.t1.micro
-          db-name: my-sql-db
-          username: originate-user
-          password-secret-name: MYSQL_PASSWORD
-          storage-type: gp2
-          service-env-var-names:
-            db-name: DATABASE_NAME
-            username: DATABASE_USERNAME
-            password: DATABASE_PASSWORD
-
 messages:
   sends:
   receives:

--- a/src/config/app_dependency_test.go
+++ b/src/config/app_dependency_test.go
@@ -159,7 +159,10 @@ var _ = Describe("AppDevelopmentDependency", func() {
 
 		var _ = Describe("GetServiceEnvVariables", func() {
 			It("should return the correct service environment variables for generic dependencies", func() {
-				expected := map[string]string{"COLLECTION_NAME": "test-collection"}
+				expected := map[string]string{
+					"COLLECTION_NAME": "test-collection",
+					"MONGO":           "mongo3.4.0",
+				}
 				Expect(mongo.GetServiceEnvVariables()).To(Equal(expected))
 			})
 		})

--- a/src/config/generic_development_dependency.go
+++ b/src/config/generic_development_dependency.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Originate/exosphere/src/docker/tools"
 	"github.com/Originate/exosphere/src/types"
@@ -38,5 +39,10 @@ func (g *genericDevelopmentDependency) GetDockerConfig() (types.DockerConfig, er
 // GetServiceEnvVariables returns the environment variables that need to
 // be passed to services that use it
 func (g *genericDevelopmentDependency) GetServiceEnvVariables() map[string]string {
-	return g.config.Config.ServiceEnvironment
+	result := map[string]string{}
+	result[strings.ToUpper(g.config.Name)] = g.GetContainerName()
+	for key, value := range g.config.Config.ServiceEnvironment {
+		result[key] = value
+	}
+	return result
 }

--- a/src/config/generic_development_dependency.go
+++ b/src/config/generic_development_dependency.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Originate/exosphere/src/docker/tools"
 	"github.com/Originate/exosphere/src/types"
+	"github.com/Originate/exosphere/src/util"
 )
 
 type genericDevelopmentDependency struct {
@@ -41,8 +42,6 @@ func (g *genericDevelopmentDependency) GetDockerConfig() (types.DockerConfig, er
 func (g *genericDevelopmentDependency) GetServiceEnvVariables() map[string]string {
 	result := map[string]string{}
 	result[strings.ToUpper(g.config.Name)] = g.GetContainerName()
-	for key, value := range g.config.Config.ServiceEnvironment {
-		result[key] = value
-	}
+	util.Merge(result, g.config.Config.ServiceEnvironment)
 	return result
 }

--- a/src/config/service_config.go
+++ b/src/config/service_config.go
@@ -99,30 +99,20 @@ func GetServiceContexts(appContext types.AppContext) (map[string]types.ServiceCo
 
 // GetBuiltServiceDevelopmentDependencies returns the dependencies for a single service
 func GetBuiltServiceDevelopmentDependencies(serviceConfig types.ServiceConfig, appConfig types.AppConfig, appDir, homeDir string) map[string]AppDevelopmentDependency {
-	appBuiltDependencies := GetBuiltAppDevelopmentDependencies(appConfig, appDir, homeDir)
-	result := map[string]AppDevelopmentDependency{}
+	result := GetBuiltAppDevelopmentDependencies(appConfig, appDir, homeDir)
 	for _, dependency := range serviceConfig.Development.Dependencies {
-		if !dependency.Config.IsEmpty() {
-			builtDependency := NewAppDevelopmentDependency(dependency, appConfig, appDir, homeDir)
-			result[dependency.Name] = builtDependency
-		} else {
-			result[dependency.Name] = appBuiltDependencies[dependency.Name]
-		}
+		builtDependency := NewAppDevelopmentDependency(dependency, appConfig, appDir, homeDir)
+		result[dependency.Name] = builtDependency
 	}
 	return result
 }
 
 // GetBuiltServiceProductionDependencies returns the dependencies for a single service
 func GetBuiltServiceProductionDependencies(serviceConfig types.ServiceConfig, appConfig types.AppConfig, appDir string) map[string]AppProductionDependency {
-	appBuiltDependencies := GetBuiltAppProductionDependencies(appConfig, appDir)
-	result := map[string]AppProductionDependency{}
+	result := GetBuiltAppProductionDependencies(appConfig, appDir)
 	for _, dependency := range serviceConfig.Production.Dependencies {
-		if !dependency.Config.IsEmpty() {
-			builtDependency := NewAppProductionDependency(dependency, appConfig, appDir)
-			result[dependency.Name] = builtDependency
-		} else {
-			result[dependency.Name] = appBuiltDependencies[dependency.Name]
-		}
+		builtDependency := NewAppProductionDependency(dependency, appConfig, appDir)
+		result[dependency.Name] = builtDependency
 	}
 	return result
 }

--- a/src/config/service_config.go
+++ b/src/config/service_config.go
@@ -99,7 +99,7 @@ func GetServiceContexts(appContext types.AppContext) (map[string]types.ServiceCo
 
 // GetBuiltServiceDevelopmentDependencies returns the dependencies for a single service
 func GetBuiltServiceDevelopmentDependencies(serviceConfig types.ServiceConfig, appConfig types.AppConfig, appDir, homeDir string) map[string]AppDevelopmentDependency {
-	result := GetBuiltAppDevelopmentDependencies(appConfig, appDir, homeDir)
+	result := map[string]AppDevelopmentDependency{}
 	for _, dependency := range serviceConfig.Development.Dependencies {
 		builtDependency := NewAppDevelopmentDependency(dependency, appConfig, appDir, homeDir)
 		result[dependency.Name] = builtDependency
@@ -109,7 +109,7 @@ func GetBuiltServiceDevelopmentDependencies(serviceConfig types.ServiceConfig, a
 
 // GetBuiltServiceProductionDependencies returns the dependencies for a single service
 func GetBuiltServiceProductionDependencies(serviceConfig types.ServiceConfig, appConfig types.AppConfig, appDir string) map[string]AppProductionDependency {
-	result := GetBuiltAppProductionDependencies(appConfig, appDir)
+	result := map[string]AppProductionDependency{}
 	for _, dependency := range serviceConfig.Production.Dependencies {
 		builtDependency := NewAppProductionDependency(dependency, appConfig, appDir)
 		result[dependency.Name] = builtDependency

--- a/src/docker/composebuilder/development.go
+++ b/src/docker/composebuilder/development.go
@@ -110,7 +110,6 @@ func (d *DevelopmentDockerComposeBuilder) getInternalServiceDockerConfigs() (typ
 		ContainerName: d.Role,
 		Command:       d.getDockerCommand(),
 		Ports:         d.getDockerPorts(),
-		Links:         d.getDockerLinks(),
 		Volumes:       d.getDockerVolumes(),
 		Environment:   d.getDockerEnvVars(),
 		DependsOn:     d.getServiceDependsOn(),
@@ -146,14 +145,6 @@ func (d *DevelopmentDockerComposeBuilder) getExternalServiceDockerConfigs() (typ
 
 func (d *DevelopmentDockerComposeBuilder) getServiceFilePath() string {
 	return path.Join(d.AppDir, d.ServiceData.Location)
-}
-
-func (d *DevelopmentDockerComposeBuilder) getDockerLinks() []string {
-	result := []string{}
-	for _, dependency := range d.ServiceConfig.Development.Dependencies {
-		result = append(result, fmt.Sprintf("%s%s:%s", dependency.Name, dependency.Version, dependency.Name))
-	}
-	return result
 }
 
 func (d *DevelopmentDockerComposeBuilder) getDockerEnvVars() map[string]string {

--- a/src/docker/composebuilder/development.go
+++ b/src/docker/composebuilder/development.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"sort"
-	"strings"
 
 	"github.com/Originate/exosphere/src/config"
 	"github.com/Originate/exosphere/src/docker/tools"
@@ -168,9 +167,6 @@ func (d *DevelopmentDockerComposeBuilder) getDockerEnvVars() map[string]string {
 		for variable, value := range builtDependency.GetServiceEnvVariables() {
 			result[variable] = value
 		}
-	}
-	for _, dependency := range d.ServiceConfig.Development.Dependencies {
-		result[strings.ToUpper(dependency.Name)] = dependency.Name
 	}
 	envVars, secrets := d.ServiceConfig.GetEnvVars("development")
 	util.Merge(result, envVars)

--- a/src/docker/composebuilder/development.go
+++ b/src/docker/composebuilder/development.go
@@ -186,10 +186,7 @@ func (d *DevelopmentDockerComposeBuilder) getServiceDependsOn() []string {
 		result = append(result, builtDependency.GetContainerName())
 	}
 	for _, builtDependency := range d.BuiltServiceDependencies {
-		containerName := builtDependency.GetContainerName()
-		if !util.DoesStringArrayContain(result, containerName) {
-			result = append(result, containerName)
-		}
+		result = append(result, builtDependency.GetContainerName())
 	}
 	sort.Strings(result)
 	return result

--- a/src/docker/composebuilder/service_test.go
+++ b/src/docker/composebuilder/service_test.go
@@ -49,13 +49,12 @@ var _ = Describe("ComposeBuilder", func() {
 					},
 					ContainerName: "mongo",
 					Command:       "node server.js",
-					Links:         []string{"mongo3.4.0:mongo"},
 					Ports:         []string{},
 					Volumes:       []string{path.Join(appDir, "mongo") + ":/mnt"},
 					Environment: map[string]string{
 						"ROLE":        "mongo",
 						"EXOCOM_HOST": "exocom0.26.1",
-						"MONGO":       "mongo",
+						"MONGO":       "mongo3.4.0",
 					},
 					Restart: "on-failure",
 				}))
@@ -207,7 +206,6 @@ var _ = Describe("ComposeBuilder", func() {
 				},
 				ContainerName: "web",
 				Command:       "",
-				Links:         []string{},
 				Ports:         []string{},
 				Volumes:       []string{path.Join(appDir, "web") + ":/mnt"},
 				Environment: map[string]string{

--- a/src/types/development_dependency_config_options.go
+++ b/src/types/development_dependency_config_options.go
@@ -7,11 +7,3 @@ type DevelopmentDependencyConfigOptions struct {
 	DependencyEnvironment map[string]string `yaml:"dependency-environment,omitempty"`
 	ServiceEnvironment    map[string]string `yaml:"service-environment,omitempty"`
 }
-
-// IsEmpty returns true if the given dependencyConfig object is empty
-func (d *DevelopmentDependencyConfigOptions) IsEmpty() bool {
-	return len(d.Ports) == 0 &&
-		len(d.Volumes) == 0 &&
-		len(d.DependencyEnvironment) == 0 &&
-		len(d.ServiceEnvironment) == 0
-}

--- a/src/types/production_dependency_config_options.go
+++ b/src/types/production_dependency_config_options.go
@@ -4,8 +4,3 @@ package types
 type ProductionDependencyConfigOptions struct {
 	Rds RdsConfig `yaml:",omitempty"`
 }
-
-// IsEmpty returns true if the given config object is empty
-func (d *ProductionDependencyConfigOptions) IsEmpty() bool {
-	return d.Rds.IsEmpty()
-}

--- a/src/types/rds_config.go
+++ b/src/types/rds_config.go
@@ -39,19 +39,6 @@ var yamlNames = map[string]string{
 	"ServiceEnvVarNames": "service-env-var-names",
 }
 
-// IsEmpty returns true if the given config object is empty
-func (d *RdsConfig) IsEmpty() bool {
-	return d.AllocatedStorage == "" &&
-		d.InstanceClass == "" &&
-		d.DbName == "" &&
-		d.Username == "" &&
-		d.PasswordSecretName == "" &&
-		d.StorageType == "" &&
-		d.ServiceEnvVarNames.DbName == "" &&
-		d.ServiceEnvVarNames.Username == "" &&
-		d.ServiceEnvVarNames.Password == ""
-}
-
 // ValidateFields validates that an rds config contains all required fields
 func (d *RdsConfig) ValidateFields() error {
 	requiredFields := []string{"AllocatedStorage", "InstanceClass", "DbName", "Username", "PasswordSecretName", "StorageType", "ServiceEnvVarNames"}


### PR DESCRIPTION
remove the weird logic tying application dependencies to service dependencies. Any application dependency is available to all services anyway.

@alexdavid was running into an issue with this when he let the config object empty. The isEmpty functions weren't used anywhere else.