### PR TITLE
convert service endpoints to constant case

### DIFF
--- a/src/docker/composebuilder/application_test.go
+++ b/src/docker/composebuilder/application_test.go
@@ -98,9 +98,9 @@ var _ = Describe("composebuilder", func() {
 			Expect(actualHtmlPort).To(Equal(expectedHtmlPort))
 
 			By("should inject the proper service endpoint environment variables")
-			expectedApiEndpointKey := "API-SERVICE_EXTERNAL_ORIGIN"
+			expectedApiEndpointKey := "API_SERVICE_EXTERNAL_ORIGIN"
 			expectedApiEndpointValue := "http://localhost:3000"
-			expectedHtmlEndpointKey := "HTML-SERVER_EXTERNAL_ORIGIN"
+			expectedHtmlEndpointKey := "HTML_SERVER_EXTERNAL_ORIGIN"
 			expectedHtmlEndpointValue := "http://localhost:3020"
 
 			skipServices := []string{"api-service", "exocom0.26.1", "mongo3.4.0"}
@@ -118,8 +118,8 @@ var _ = Describe("composebuilder", func() {
 				Expect(dockerConfig.Environment[expectedHtmlEndpointKey]).To(Equal(expectedHtmlEndpointValue))
 			}
 			nonPublicServiceKeys := []string{
-				"USERS-SERVICE_EXTERNAL_ORIGIN",
-				"TODO-SERVICE_EXTERNAL_ORIGIN",
+				"USERS_SERVICE_EXTERNAL_ORIGIN",
+				"TODO_SERVICE_EXTERNAL_ORIGIN",
 			}
 			for _, dockerConfig := range dockerConfigs {
 				for _, nonPublicKey := range nonPublicServiceKeys {

--- a/src/docker/composebuilder/service_endpoints.go
+++ b/src/docker/composebuilder/service_endpoints.go
@@ -51,10 +51,17 @@ func (s *ServiceEndpoints) GetEndpointMappings() map[string]string {
 	}
 	switch s.ServiceConfig.Type {
 	case "public":
-		externalKey := fmt.Sprintf("%s_EXTERNAL_ORIGIN", strings.ToUpper(s.ServiceRole))
+		externalKey := fmt.Sprintf("%s_EXTERNAL_ORIGIN", toConstantCase(s.ServiceRole))
 		externalValue := fmt.Sprintf("http://localhost:%s", s.HostPort)
 		return map[string]string{externalKey: externalValue}
 	default:
 		return map[string]string{}
 	}
+}
+
+// converts valid serviceRole strings to constant case
+// see validateAppConfig() in types/app_config.go for valid serviceRole regex
+func toConstantCase(serviceRole string) string {
+	str := strings.Join(strings.Split(serviceRole, "-"), "_")
+	return strings.ToUpper(str)
 }


### PR DESCRIPTION
Resolves https://github.com/Originate/exosphere/issues/781

I decided to put the `toConstantCase` function in the ServiceEndpoints struct, since it would be way too difficult to convert any possible string to constant case. We can control what gets passed in here because it will always be a service role