### PR TITLE
inject external origin endpoint in production

### DIFF
--- a/src/docker/composebuilder/service_builder_test.go
+++ b/src/docker/composebuilder/service_builder_test.go
@@ -216,6 +216,8 @@ var _ = Describe("building for local production", func() {
 			Volumes:       []string{"${APP_PATH}/web:/mnt"},
 			Environment: map[string]string{
 				"ROLE":        "web",
+				"ENV1":        "value1",
+				"API_KEY":     "",
 				"EXOCOM_HOST": "exocom0.26.1",
 			},
 			DependsOn: []string{"exocom0.26.1"},

--- a/test/fixtures/applications/simple/web/service.yml
+++ b/test/fixtures/applications/simple/web/service.yml
@@ -11,3 +11,11 @@ messages:
 development:
   scripts:
     run: node server.js
+
+environment:
+  default:
+    ENV1: value1
+  development:
+  production:
+  secrets:
+    - API_KEY


### PR DESCRIPTION
Resolves https://github.com/Originate/exosphere/issues/780

Also makes a change to read env vars from `run_production.yml` instead of generating those variables again. I thought this was more idiomatic, but unfortunately that meant we needed to checkout an example app in the terraform unit test, which caused a lot of changes.

No test cases have been deleted, they've simply been merged or moved around.