### PR TITLE
Move buildmode to types

### DIFF
--- a/src/application/clean.go
+++ b/src/application/clean.go
@@ -17,9 +17,9 @@ func CleanContainers(appContext types.AppContext, writer io.Writer) error {
 	if err != nil {
 		return err
 	}
-	for _, dockerComposeFileName := range composebuilder.GetComposeFileNames() {
+	for _, dockerComposeFileName := range types.GetComposeFileNames() {
 		var composeProjectName string
-		if dockerComposeFileName == composebuilder.LocalTestComposeFileName {
+		if dockerComposeFileName == types.LocalTestComposeFileName {
 			composeProjectName = composebuilder.GetTestDockerComposeProjectName(appContext.Config.Name)
 		} else {
 			composeProjectName = composebuilder.GetDockerComposeProjectName(appContext.Config.Name)

--- a/src/application/deployer/push_application_images.go
+++ b/src/application/deployer/push_application_images.go
@@ -4,7 +4,6 @@ import (
 	"path"
 
 	"github.com/Originate/exosphere/src/aws"
-	"github.com/Originate/exosphere/src/docker/composebuilder"
 	"github.com/Originate/exosphere/src/docker/tools"
 	"github.com/Originate/exosphere/src/types"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/src/application/deployer/push_application_images.go
+++ b/src/application/deployer/push_application_images.go
@@ -20,9 +20,9 @@ func PushApplicationImages(deployConfig types.DeployConfig) (map[string]string, 
 	if err != nil {
 		return nil, err
 	}
-	buildMode := composebuilder.BuildMode{
-		Type:        composebuilder.BuildModeTypeDeploy,
-		Environment: composebuilder.BuildModeEnvironmentProduction,
+	buildMode := types.BuildMode{
+		Type:        types.BuildModeTypeDeploy,
+		Environment: types.BuildModeEnvironmentProduction,
 	}
 	dockerCompose, err := tools.GetDockerCompose(path.Join(deployConfig.DockerComposeDir, buildMode.GetDockerComposeFileName()))
 	if err != nil {

--- a/src/application/deployer/push_image_options.go
+++ b/src/application/deployer/push_image_options.go
@@ -1,7 +1,6 @@
 package deployer
 
 import (
-	"github.com/Originate/exosphere/src/docker/composebuilder"
 	"github.com/Originate/exosphere/src/types"
 	"github.com/aws/aws-sdk-go/service/ecr"
 )

--- a/src/application/deployer/push_image_options.go
+++ b/src/application/deployer/push_image_options.go
@@ -15,5 +15,5 @@ type PushImageOptions struct {
 	ServiceLocation string
 	ServiceRole     string
 	BuildImage      bool
-	BuildMode       composebuilder.BuildMode
+	BuildMode       types.BuildMode
 }

--- a/src/application/generate.go
+++ b/src/application/generate.go
@@ -12,19 +12,19 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var buildModes = []composebuilder.BuildMode{
-	composebuilder.BuildMode{
-		Type:        composebuilder.BuildModeTypeLocal,
-		Environment: composebuilder.BuildModeEnvironmentTest,
+var buildModes = []types.BuildMode{
+	types.BuildMode{
+		Type:        types.BuildModeTypeLocal,
+		Environment: types.BuildModeEnvironmentTest,
 	},
-	composebuilder.BuildMode{
-		Type:        composebuilder.BuildModeTypeLocal,
+	types.BuildMode{
+		Type:        types.BuildModeTypeLocal,
 		Mount:       true,
-		Environment: composebuilder.BuildModeEnvironmentDevelopment,
+		Environment: types.BuildModeEnvironmentDevelopment,
 	},
-	composebuilder.BuildMode{
-		Type:        composebuilder.BuildModeTypeLocal,
-		Environment: composebuilder.BuildModeEnvironmentProduction,
+	types.BuildMode{
+		Type:        types.BuildModeTypeLocal,
+		Environment: types.BuildModeEnvironmentProduction,
 	},
 }
 

--- a/src/application/runner.go
+++ b/src/application/runner.go
@@ -20,11 +20,11 @@ type Runner struct {
 	DockerComposeDir         string
 	DockerComposeProjectName string
 	Writer                   io.Writer
-	BuildMode                composebuilder.BuildMode
+	BuildMode                types.BuildMode
 }
 
 // NewRunner is Runner's constructor
-func NewRunner(appContext types.AppContext, writer io.Writer, dockerComposeProjectName string, buildMode composebuilder.BuildMode) (*Runner, error) {
+func NewRunner(appContext types.AppContext, writer io.Writer, dockerComposeProjectName string, buildMode types.BuildMode) (*Runner, error) {
 	serviceConfigs, err := config.GetServiceConfigs(appContext.Location, appContext.Config)
 	if err != nil {
 		return &Runner{}, err

--- a/src/application/runner.go
+++ b/src/application/runner.go
@@ -7,7 +7,6 @@ import (
 	"path"
 
 	"github.com/Originate/exosphere/src/config"
-	"github.com/Originate/exosphere/src/docker/composebuilder"
 	"github.com/Originate/exosphere/src/docker/composerunner"
 	"github.com/Originate/exosphere/src/types"
 )

--- a/src/application/tester/test_runner.go
+++ b/src/application/tester/test_runner.go
@@ -14,13 +14,13 @@ import (
 // TestRunner runs the tests for the given service
 type TestRunner struct {
 	AppContext types.AppContext
-	BuildMode  composebuilder.BuildMode
+	BuildMode  types.BuildMode
 	RunOptions composerunner.RunOptions
 	Writer     io.Writer
 }
 
 // NewTestRunner is TestRunner's constructor
-func NewTestRunner(appContext types.AppContext, writer io.Writer, mode composebuilder.BuildMode) (*TestRunner, error) {
+func NewTestRunner(appContext types.AppContext, writer io.Writer, mode types.BuildMode) (*TestRunner, error) {
 	tester := &TestRunner{
 		AppContext: appContext,
 		BuildMode:  mode,

--- a/src/application/tester/tester.go
+++ b/src/application/tester/tester.go
@@ -14,7 +14,7 @@ import (
 
 // TestApp runs the tests for the entire application and return true if the tests passed
 // and an error if any
-func TestApp(appContext types.AppContext, writer io.Writer, mode composebuilder.BuildMode, shutdown chan os.Signal) (types.TestResult, error) {
+func TestApp(appContext types.AppContext, writer io.Writer, mode types.BuildMode, shutdown chan os.Signal) (types.TestResult, error) {
 	serviceContexts, err := config.GetServiceContexts(appContext)
 	if err != nil {
 		return types.TestResult{}, err
@@ -79,7 +79,7 @@ func printResults(failedTests []string, writer io.Writer) error {
 
 // TestService runs the tests for the service and return true if the tests passed
 // and an error if any
-func TestService(context types.Context, writer io.Writer, mode composebuilder.BuildMode, shutdown chan os.Signal) (types.TestResult, error) {
+func TestService(context types.Context, writer io.Writer, mode types.BuildMode, shutdown chan os.Signal) (types.TestResult, error) {
 	testRunner, err := NewTestRunner(context.AppContext, writer, mode)
 	if err != nil {
 		return types.TestResult{}, err

--- a/src/application/tester/tester.go
+++ b/src/application/tester/tester.go
@@ -6,7 +6,6 @@ import (
 	"path"
 
 	"github.com/Originate/exosphere/src/config"
-	"github.com/Originate/exosphere/src/docker/composebuilder"
 	"github.com/Originate/exosphere/src/types"
 	"github.com/Originate/exosphere/src/util"
 	"github.com/fatih/color"

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -25,13 +25,13 @@ var runCmd = &cobra.Command{
 		}
 		dockerComposeProjectName := composebuilder.GetDockerComposeProjectName(context.AppContext.Config.Name)
 		writer := os.Stdout
-		buildMode := composebuilder.BuildMode{
-			Type:        composebuilder.BuildModeTypeLocal,
+		buildMode := types.BuildMode{
+			Type:        types.BuildModeTypeLocal,
 			Mount:       true,
-			Environment: composebuilder.BuildModeEnvironmentDevelopment,
+			Environment: types.BuildModeEnvironmentDevelopment,
 		}
 		if productionFlag {
-			buildMode.Environment = composebuilder.BuildModeEnvironmentProduction
+			buildMode.Environment = types.BuildModeEnvironmentProduction
 		}
 		runner, err := application.NewRunner(context.AppContext, writer, dockerComposeProjectName, buildMode)
 		if err != nil {

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Originate/exosphere/src/application"
 	"github.com/Originate/exosphere/src/docker/composebuilder"
+	"github.com/Originate/exosphere/src/types"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/test.go
+++ b/src/cmd/test.go
@@ -6,7 +6,6 @@ import (
 	"os/signal"
 
 	"github.com/Originate/exosphere/src/application/tester"
-	"github.com/Originate/exosphere/src/docker/composebuilder"
 	"github.com/Originate/exosphere/src/types"
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/test.go
+++ b/src/cmd/test.go
@@ -25,9 +25,9 @@ var testCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		writer := os.Stdout
-		buildMode := composebuilder.BuildMode{
-			Type:        composebuilder.BuildModeTypeLocal,
-			Environment: composebuilder.BuildModeEnvironmentTest,
+		buildMode := types.BuildMode{
+			Type:        types.BuildModeTypeLocal,
+			Environment: types.BuildModeEnvironmentTest,
 		}
 
 		shutdownChannel := make(chan os.Signal, 1)

--- a/src/docker/composebuilder/application_options.go
+++ b/src/docker/composebuilder/application_options.go
@@ -8,5 +8,5 @@ import (
 type ApplicationOptions struct {
 	AppConfig types.AppConfig
 	AppDir    string
-	BuildMode BuildMode
+	BuildMode types.BuildMode
 }

--- a/src/docker/composebuilder/index.go
+++ b/src/docker/composebuilder/index.go
@@ -38,7 +38,7 @@ func GetApplicationDockerCompose(options ApplicationOptions) (*types.DockerCompo
 // getDependenciesDockerConfigs returns the docker configs for all the application dependencies
 func getDependenciesDockerConfigs(options ApplicationOptions) (*types.DockerCompose, error) {
 	result := types.NewDockerCompose()
-	if options.BuildMode.Type == BuildModeTypeDeploy {
+	if options.BuildMode.Type == types.BuildModeTypeDeploy {
 		appDependencies := config.GetBuiltAppProductionDependencies(options.AppConfig, options.AppDir)
 		for _, builtDependency := range appDependencies {
 			if builtDependency.HasDockerConfig() {

--- a/src/docker/composebuilder/index_test.go
+++ b/src/docker/composebuilder/index_test.go
@@ -30,9 +30,9 @@ var _ = Describe("composebuilder", func() {
 			dockerCompose, err := composebuilder.GetApplicationDockerCompose(composebuilder.ApplicationOptions{
 				AppConfig: appConfig,
 				AppDir:    appDir,
-				BuildMode: composebuilder.BuildMode{
-					Type:        composebuilder.BuildModeTypeLocal,
-					Environment: composebuilder.BuildModeEnvironmentDevelopment,
+				BuildMode: types.BuildMode{
+					Type:        types.BuildModeTypeLocal,
+					Environment: types.BuildModeEnvironmentDevelopment,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/src/docker/composebuilder/service_builder.go
+++ b/src/docker/composebuilder/service_builder.go
@@ -16,7 +16,7 @@ type ServiceComposeBuilder struct {
 	AppConfig                types.AppConfig
 	ServiceConfig            types.ServiceConfig
 	ServiceData              types.ServiceData
-	Mode                     BuildMode
+	Mode                     types.BuildMode
 	BuiltAppDependencies     map[string]config.AppDevelopmentDependency
 	BuiltServiceDependencies map[string]config.AppDevelopmentDependency
 	Role                     string
@@ -25,13 +25,13 @@ type ServiceComposeBuilder struct {
 }
 
 // GetServiceDockerCompose returns the DockerConfigs for a service and its dependencies in docker-compose.yml
-func GetServiceDockerCompose(appConfig types.AppConfig, serviceConfig types.ServiceConfig, serviceData types.ServiceData, role string, appDir string, mode BuildMode, serviceEndpoints map[string]*ServiceEndpoints) (*types.DockerCompose, error) {
+func GetServiceDockerCompose(appConfig types.AppConfig, serviceConfig types.ServiceConfig, serviceData types.ServiceData, role string, appDir string, mode types.BuildMode, serviceEndpoints map[string]*ServiceEndpoints) (*types.DockerCompose, error) {
 	return NewServiceComposeBuilder(appConfig, serviceConfig, serviceData, role, appDir, mode, serviceEndpoints).getServiceDockerConfigs()
 }
 
 // NewServiceComposeBuilder is ServiceComposeBuilder's constructor
-func NewServiceComposeBuilder(appConfig types.AppConfig, serviceConfig types.ServiceConfig, serviceData types.ServiceData, role, appDir string, mode BuildMode, serviceEndpoints map[string]*ServiceEndpoints) *ServiceComposeBuilder {
-	if mode.Environment == BuildModeEnvironmentTest {
+func NewServiceComposeBuilder(appConfig types.AppConfig, serviceConfig types.ServiceConfig, serviceData types.ServiceData, role, appDir string, mode types.BuildMode, serviceEndpoints map[string]*ServiceEndpoints) *ServiceComposeBuilder {
+	if mode.Environment == types.BuildModeEnvironmentTest {
 		role = appConfig.GetTestRole(role)
 	}
 	return &ServiceComposeBuilder{
@@ -59,7 +59,7 @@ func (d *ServiceComposeBuilder) getServiceDockerConfigs() (*types.DockerCompose,
 }
 
 func (d *ServiceComposeBuilder) getDockerfileName() string {
-	if d.Mode.Environment == BuildModeEnvironmentProduction {
+	if d.Mode.Environment == types.BuildModeEnvironmentProduction {
 		return "Dockerfile.prod"
 	}
 	return "Dockerfile.dev"
@@ -67,9 +67,9 @@ func (d *ServiceComposeBuilder) getDockerfileName() string {
 
 func (d *ServiceComposeBuilder) getDockerCommand() string {
 	switch d.Mode.Environment {
-	case BuildModeEnvironmentProduction:
+	case types.BuildModeEnvironmentProduction:
 		return ""
-	case BuildModeEnvironmentTest:
+	case types.BuildModeEnvironmentTest:
 		return d.ServiceConfig.Development.Scripts["test"]
 	default:
 		return d.ServiceConfig.Development.Scripts["run"]
@@ -78,9 +78,9 @@ func (d *ServiceComposeBuilder) getDockerCommand() string {
 
 func (d *ServiceComposeBuilder) getDockerPorts() []string {
 	switch d.Mode.Environment {
-	case BuildModeEnvironmentProduction:
+	case types.BuildModeEnvironmentProduction:
 		fallthrough
-	case BuildModeEnvironmentDevelopment:
+	case types.BuildModeEnvironmentDevelopment:
 		return d.ServiceEndpoints[d.Role].GetPortMappings()
 	default:
 		return []string{}
@@ -95,7 +95,7 @@ func (d *ServiceComposeBuilder) getDockerVolumes() []string {
 }
 
 func (d *ServiceComposeBuilder) getRestartPolicy() string {
-	if d.Mode.Environment != BuildModeEnvironmentTest {
+	if d.Mode.Environment != types.BuildModeEnvironmentTest {
 		return "on-failure"
 	}
 	return ""
@@ -125,7 +125,7 @@ func (d *ServiceComposeBuilder) getInternalServiceDockerCompose() (*types.Docker
 
 func (d *ServiceComposeBuilder) getExternalServiceDockerCompose() (*types.DockerCompose, error) {
 	result := types.NewDockerCompose()
-	if d.Mode.Environment == BuildModeEnvironmentTest {
+	if d.Mode.Environment == types.BuildModeEnvironmentTest {
 		return result, nil
 	}
 	result.Services[d.Role] = types.DockerConfig{

--- a/src/docker/composebuilder/service_builder_test.go
+++ b/src/docker/composebuilder/service_builder_test.go
@@ -26,10 +26,10 @@ var _ = Describe("ComposeBuilder", func() {
 			Expect(err).NotTo(HaveOccurred())
 			serviceData := appConfig.Services
 			serviceRole := "mongo"
-			buildMode := composebuilder.BuildMode{
-				Type:        composebuilder.BuildModeTypeLocal,
+			buildMode := types.BuildMode{
+				Type:        types.BuildModeTypeLocal,
 				Mount:       true,
-				Environment: composebuilder.BuildModeEnvironmentDevelopment,
+				Environment: types.BuildModeEnvironmentDevelopment,
 			}
 			serviceEndpoints = map[string]*composebuilder.ServiceEndpoints{
 				"mongo": &composebuilder.ServiceEndpoints{},
@@ -107,9 +107,9 @@ var _ = Describe("ComposeBuilder", func() {
 		})
 
 		It("compiles development variables", func() {
-			buildMode := composebuilder.BuildMode{
-				Type:        composebuilder.BuildModeTypeLocal,
-				Environment: composebuilder.BuildModeEnvironmentDevelopment,
+			buildMode := types.BuildMode{
+				Type:        types.BuildModeTypeLocal,
+				Environment: types.BuildModeEnvironmentDevelopment,
 			}
 			dockerCompose, err := composebuilder.GetServiceDockerCompose(appConfig, serviceConfigs[serviceRole], serviceData[serviceRole], serviceRole, appDir, buildMode, serviceEndpoints)
 			Expect(err).NotTo(HaveOccurred())
@@ -138,9 +138,9 @@ var _ = Describe("ComposeBuilder", func() {
 			Expect(err).NotTo(HaveOccurred())
 			serviceData := appConfig.Services
 			serviceRole := "postgres-service"
-			buildMode := composebuilder.BuildMode{
-				Type:        composebuilder.BuildModeTypeLocal,
-				Environment: composebuilder.BuildModeEnvironmentDevelopment,
+			buildMode := types.BuildMode{
+				Type:        types.BuildModeTypeLocal,
+				Environment: types.BuildModeEnvironmentDevelopment,
 			}
 			serviceEndpoints = map[string]*composebuilder.ServiceEndpoints{
 				"postgres-service": &composebuilder.ServiceEndpoints{},
@@ -170,10 +170,10 @@ var _ = Describe("building for local production", func() {
 		Expect(err).NotTo(HaveOccurred())
 		serviceData := appConfig.Services
 		serviceRole := "web"
-		buildMode := composebuilder.BuildMode{
-			Type:        composebuilder.BuildModeTypeLocal,
+		buildMode := types.BuildMode{
+			Type:        types.BuildModeTypeLocal,
 			Mount:       true,
-			Environment: composebuilder.BuildModeEnvironmentProduction,
+			Environment: types.BuildModeEnvironmentProduction,
 		}
 		serviceEndpoints = map[string]*composebuilder.ServiceEndpoints{
 			"web": &composebuilder.ServiceEndpoints{},

--- a/src/docker/composebuilder/service_endpoints.go
+++ b/src/docker/composebuilder/service_endpoints.go
@@ -16,12 +16,12 @@ type ServiceEndpoints struct {
 }
 
 // NewServiceEndpoint initializes a ServiceEndpoint struct
-func NewServiceEndpoint(serviceRole string, serviceConfig types.ServiceConfig, portReservation *types.PortReservation, buildMode BuildMode) *ServiceEndpoints {
+func NewServiceEndpoint(serviceRole string, serviceConfig types.ServiceConfig, portReservation *types.PortReservation, buildMode types.BuildMode) *ServiceEndpoints {
 	containerPort := ""
 	switch buildMode.Environment {
-	case BuildModeEnvironmentDevelopment:
+	case types.BuildModeEnvironmentDevelopment:
 		containerPort = serviceConfig.Development.Port
-	case BuildModeEnvironmentProduction:
+	case types.BuildModeEnvironmentProduction:
 		containerPort = serviceConfig.Production.Port
 	}
 	hostPort := ""

--- a/src/types/build_mode.go
+++ b/src/types/build_mode.go
@@ -1,4 +1,4 @@
-package composebuilder
+package types
 
 // BuildMode determines what type of docker compose config should be created
 type BuildMode struct {


### PR DESCRIPTION
~This will allow for changes coming in a later PR.~

I thought I needed these changes in a later PR but it turns out I don't. Let me know what you guys think of this anyways. In the future this will allow us to do things like attach `BuildMode` as a field of `DeployConfig`. We couldn't do this before because we'd get an import cycle.