### PR TITLE
less verbose test errors

### DIFF
--- a/test/helpers/shared_feature_context.go
+++ b/test/helpers/shared_feature_context.go
@@ -132,28 +132,19 @@ func SharedFeatureContext(s *godog.Suite) {
 	s.Step(`^running "([^"]*)" in the terminal$`, func(command string) error {
 		var err error
 		childOutput, err = util.Run(appDir, command)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 
 	s.Step(`^running "([^"]*)" in my application directory$`, func(command string) error {
 		var err error
 		childOutput, err = util.Run(appDir, command)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 
 	s.Step(`^running "([^"]*)" in the "([^"]*)" directory$`, func(command, dirName string) error {
 		var err error
 		childOutput, err = util.Run(path.Join(appDir, dirName), command)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 
 	s.Step(`^starting "([^"]*)" in the terminal$`, func(command string) error {

--- a/test/helpers/shared_feature_context.go
+++ b/test/helpers/shared_feature_context.go
@@ -133,7 +133,7 @@ func SharedFeatureContext(s *godog.Suite) {
 		var err error
 		childOutput, err = util.Run(appDir, command)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Command errored with output: %s", childOutput))
+			return err
 		}
 		return nil
 	})
@@ -142,7 +142,7 @@ func SharedFeatureContext(s *godog.Suite) {
 		var err error
 		childOutput, err = util.Run(appDir, command)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Command errored with output: %s", childOutput))
+			return err
 		}
 		return nil
 	})
@@ -151,7 +151,7 @@ func SharedFeatureContext(s *godog.Suite) {
 		var err error
 		childOutput, err = util.Run(path.Join(appDir, dirName), command)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Command errored with output: %s", childOutput))
+			return err
 		}
 		return nil
 	})


### PR DESCRIPTION
extracted from #812

util.Run already wraps errors with the command running and the output. Thus this extra wrapping to making the output appear twice