### PR TITLE
Implement global remote env vars

### DIFF
--- a/src/terraform/command_helpers.go
+++ b/src/terraform/command_helpers.go
@@ -14,20 +14,20 @@ import (
 
 // CompileVarFlags compiles the variable flags passed into a Terraform command
 func CompileVarFlags(deployConfig deploy.Config, secrets types.Secrets, imagesMap map[string]string) ([]string, error) {
-	varFlagsMap := CompileDockerImageVars(deployConfig, imagesMap)
-	envVars, err := CompileServiceEnvVars(deployConfig, secrets)
+	varMap := GetDockerImageVarMap(deployConfig, imagesMap)
+	servicesVarMap, err := GetServicesVarMap(deployConfig, secrets)
 	if err != nil {
 		return []string{}, errors.Wrap(err, "cannot compile service environment variables")
 	}
-	util.Merge(varFlagsMap, envVars)
-	dependencyVars, err := CompileDependencyVars(deployConfig)
+	util.Merge(varMap, servicesVarMap)
+	dependenciesVarMap, err := GetDependenciesVarMap(deployConfig)
 	if err != nil {
 		return []string{}, errors.Wrap(err, "cannot compile dependency variables")
 	}
-	util.Merge(varFlagsMap, dependencyVars)
-	util.Merge(varFlagsMap, map[string]string{"aws_profile": deployConfig.AwsConfig.Profile})
-	util.Merge(varFlagsMap, secrets)
-	return BuildFlags(varFlagsMap), nil
+	util.Merge(varMap, dependenciesVarMap)
+	util.Merge(varMap, secrets)
+	varMap["aws_profile"] = deployConfig.AwsConfig.Profile
+	return BuildFlags(varMap), nil
 }
 
 // BuildFlags builds a map[string]string object into terraform var flags
@@ -39,8 +39,8 @@ func BuildFlags(varMap map[string]string) []string {
 	return varFlags
 }
 
-// CompileDockerImageVars compiles the docker image variables for each service
-func CompileDockerImageVars(deployConfig deploy.Config, imagesMap map[string]string) map[string]string {
+// GetDockerImageVarMap compiles the docker image variables for each service
+func GetDockerImageVarMap(deployConfig deploy.Config, imagesMap map[string]string) map[string]string {
 	dockerImages := map[string]string{}
 	for serviceRole, serviceContext := range deployConfig.AppContext.ServiceContexts {
 		dockerImages[fmt.Sprintf("%s_docker_image", serviceRole)] = imagesMap[serviceRole]
@@ -54,8 +54,8 @@ func CompileDockerImageVars(deployConfig deploy.Config, imagesMap map[string]str
 	return dockerImages
 }
 
-// CompileDependencyVars compiles variables  needed for each dependency
-func CompileDependencyVars(deployConfig deploy.Config) (map[string]string, error) {
+// GetDependenciesVarMap compiles variables  needed for each dependency
+func GetDependenciesVarMap(deployConfig deploy.Config) (map[string]string, error) {
 	dependencyVars := map[string]string{}
 	for dependencyName, dependency := range config.GetBuiltRemoteAppDependencies(deployConfig.AppContext) {
 		varMap, err := dependency.GetDeploymentVariables()
@@ -84,8 +84,8 @@ func CompileDependencyVars(deployConfig deploy.Config) (map[string]string, error
 	return dependencyVars, nil
 }
 
-// CompileServiceEnvVars compiles env vars needed for each service
-func CompileServiceEnvVars(deployConfig deploy.Config, secrets types.Secrets) (map[string]string, error) {
+// GetServicesVarMap compiles env vars needed for each service
+func GetServicesVarMap(deployConfig deploy.Config, secrets types.Secrets) (map[string]string, error) {
 	envVars := map[string]string{}
 	serviceEndpoints := endpoints.NewServiceEndpoints(deployConfig.AppContext, types.BuildModeDeploy)
 	for serviceRole, serviceContext := range deployConfig.AppContext.ServiceContexts {

--- a/src/terraform/command_helpers.go
+++ b/src/terraform/command_helpers.go
@@ -14,79 +14,79 @@ import (
 
 // CompileVarFlags compiles the variable flags passed into a Terraform command
 func CompileVarFlags(deployConfig deploy.Config, secrets types.Secrets, imagesMap map[string]string) ([]string, error) {
-	vars := compileSecrets(secrets)
-	imageVars := compileDockerImageVars(deployConfig, imagesMap)
-	vars = append(vars, imageVars...)
-	envVars, err := compileServiceEnvVars(deployConfig, secrets)
+	varFlagsMap := CompileDockerImageVars(deployConfig, imagesMap)
+	envVars, err := CompileServiceEnvVars(deployConfig, secrets)
 	if err != nil {
 		return []string{}, errors.Wrap(err, "cannot compile service environment variables")
 	}
-	vars = append(vars, envVars...)
-	dependencyVars, err := compileDependencyVars(deployConfig)
+	util.Merge(varFlagsMap, envVars)
+	dependencyVars, err := CompileDependencyVars(deployConfig)
 	if err != nil {
 		return []string{}, errors.Wrap(err, "cannot compile dependency variables")
 	}
-	vars = append(vars, dependencyVars...)
-	return append(vars, "-var", fmt.Sprintf("aws_profile=%s", deployConfig.AwsConfig.Profile)), nil
+	util.Merge(varFlagsMap, dependencyVars)
+	util.Merge(varFlagsMap, map[string]string{"aws_profile": deployConfig.AwsConfig.Profile})
+	util.Merge(varFlagsMap, secrets)
+	return BuildFlags(varFlagsMap), nil
 }
 
-// compile all secrets into var flags
-func compileSecrets(secrets types.Secrets) []string {
-	vars := []string{}
-	for k, v := range secrets {
-		vars = append(vars, "-var", fmt.Sprintf("%s=%s", k, v))
+// BuildFlags builds a map[string]string object into terraform var flags
+func BuildFlags(varMap map[string]string) []string {
+	varFlags := []string{}
+	for k, v := range varMap {
+		varFlags = append(varFlags, "-var", fmt.Sprintf("%s=%s", k, v))
 	}
-	return vars
+	return varFlags
 }
 
-// compile docker image var flags for each service
-func compileDockerImageVars(deployConfig deploy.Config, imagesMap map[string]string) []string {
-	vars := []string{}
+// CompileDockerImageVars compiles the docker image variables for each service
+func CompileDockerImageVars(deployConfig deploy.Config, imagesMap map[string]string) map[string]string {
+	dockerImages := map[string]string{}
 	for serviceRole, serviceContext := range deployConfig.AppContext.ServiceContexts {
-		vars = append(vars, "-var", fmt.Sprintf("%s_docker_image=%s", serviceRole, imagesMap[serviceRole]))
+		dockerImages[fmt.Sprintf("%s_docker_image", serviceRole)] = imagesMap[serviceRole]
 		for dependencyName := range serviceContext.Config.Remote.Dependencies {
-			vars = append(vars, "-var", fmt.Sprintf("%s_docker_image=%s", dependencyName, imagesMap[dependencyName]))
+			dockerImages[fmt.Sprintf("%s_docker_image", dependencyName)] = imagesMap[dependencyName]
 		}
 	}
 	for dependencyName := range deployConfig.AppContext.Config.Remote.Dependencies {
-		vars = append(vars, "-var", fmt.Sprintf("%s_docker_image=%s", dependencyName, imagesMap[dependencyName]))
+		dockerImages[fmt.Sprintf("%s_docker_image", dependencyName)] = imagesMap[dependencyName]
 	}
-	return vars
+	return dockerImages
 }
 
-// compile var flags needed for each dependency
-func compileDependencyVars(deployConfig deploy.Config) ([]string, error) {
-	vars := []string{}
+// CompileDependencyVars compiles variables  needed for each dependency
+func CompileDependencyVars(deployConfig deploy.Config) (map[string]string, error) {
+	dependencyVars := map[string]string{}
 	for dependencyName, dependency := range config.GetBuiltRemoteAppDependencies(deployConfig.AppContext) {
 		varMap, err := dependency.GetDeploymentVariables()
 		if err != nil {
-			return []string{}, err
+			return map[string]string{}, err
 		}
 		stringifiedVar, err := createEnvVarString(varMap)
 		if err != nil {
-			return []string{}, err
+			return map[string]string{}, err
 		}
-		vars = append(vars, "-var", fmt.Sprintf("%s_env_vars=%s", dependencyName, stringifiedVar))
+		dependencyVars[fmt.Sprintf("%s_env_vars", dependencyName)] = stringifiedVar
 	}
 	for _, serviceContext := range deployConfig.AppContext.ServiceContexts {
 		for dependencyName, dependency := range config.GetBuiltRemoteServiceDependencies(serviceContext.Config, deployConfig.AppContext) {
 			varMap, err := dependency.GetDeploymentVariables()
 			if err != nil {
-				return []string{}, err
+				return map[string]string{}, err
 			}
 			stringifiedVar, err := createEnvVarString(varMap)
 			if err != nil {
-				return []string{}, err
+				return map[string]string{}, err
 			}
-			vars = append(vars, "-var", fmt.Sprintf("%s_env_vars=%s", dependencyName, stringifiedVar))
+			dependencyVars[fmt.Sprintf("%s_env_vars", dependencyName)] = stringifiedVar
 		}
 	}
-	return vars, nil
+	return dependencyVars, nil
 }
 
-// compile env vars needed for each service
-func compileServiceEnvVars(deployConfig deploy.Config, secrets types.Secrets) ([]string, error) {
-	envVars := []string{}
+// CompileServiceEnvVars compiles env vars needed for each service
+func CompileServiceEnvVars(deployConfig deploy.Config, secrets types.Secrets) (map[string]string, error) {
+	envVars := map[string]string{}
 	serviceEndpoints := endpoints.NewServiceEndpoints(deployConfig.AppContext, deployConfig.BuildMode)
 	for serviceRole, serviceContext := range deployConfig.AppContext.ServiceContexts {
 		serviceEnvVars := map[string]string{"ROLE": serviceRole}
@@ -101,9 +101,9 @@ func compileServiceEnvVars(deployConfig deploy.Config, secrets types.Secrets) ([
 		util.Merge(serviceEnvVars, endpointEnvVars)
 		serviceEnvVarsStr, err := createEnvVarString(serviceEnvVars)
 		if err != nil {
-			return []string{}, err
+			return map[string]string{}, err
 		}
-		envVars = append(envVars, "-var", fmt.Sprintf("%s_env_vars=%s", serviceRole, serviceEnvVarsStr))
+		envVars[fmt.Sprintf("%s_env_vars", serviceRole)] = serviceEnvVarsStr
 	}
 	return envVars, nil
 }

--- a/src/terraform/command_helpers.go
+++ b/src/terraform/command_helpers.go
@@ -90,11 +90,15 @@ func CompileServiceEnvVars(deployConfig deploy.Config, secrets types.Secrets) (m
 	serviceEndpoints := endpoints.NewServiceEndpoints(deployConfig.AppContext, types.BuildModeDeploy)
 	for serviceRole, serviceContext := range deployConfig.AppContext.ServiceContexts {
 		serviceEnvVars := map[string]string{"ROLE": serviceRole}
+		util.Merge(serviceEnvVars, deployConfig.AppContext.Config.Remote.Environment)
 		dependencyEnvVars := getDependencyServiceEnvVars(deployConfig, serviceContext.Config, secrets)
 		util.Merge(serviceEnvVars, dependencyEnvVars)
 		productionEnvVar := serviceContext.Config.Remote.Environment
 		util.Merge(serviceEnvVars, productionEnvVar)
 		for _, secretKey := range serviceContext.Config.Remote.Secrets {
+			serviceEnvVars[secretKey] = secrets[secretKey]
+		}
+		for _, secretKey := range deployConfig.AppContext.Config.Remote.Secrets {
 			serviceEnvVars[secretKey] = secrets[secretKey]
 		}
 		endpointEnvVars := serviceEndpoints.GetServiceEndpointEnvVars(serviceRole)

--- a/src/terraform/command_helpers_test.go
+++ b/src/terraform/command_helpers_test.go
@@ -205,6 +205,10 @@ var _ = Describe("CompileVarFlags", func() {
 					"service1": {
 						Config: types.ServiceConfig{
 							Remote: types.ServiceRemoteConfig{
+								Environment: map[string]string{
+									"TEST_APP_ENV": "TEST_APP_ENV_VAL",
+								},
+								Secrets: []string{"password-secret"},
 								Dependencies: map[string]types.RemoteDependency{
 									"postgres": types.RemoteDependency{
 										Type: "rds",
@@ -254,6 +258,14 @@ var _ = Describe("CompileVarFlags", func() {
 				{
 					"name":  "ROLE",
 					"value": "service1",
+				},
+				{
+					"name":  "TEST_APP_ENV",
+					"value": "TEST_APP_ENV_VAL",
+				},
+				{
+					"name":  "password-secret",
+					"value": "password123",
 				},
 			}
 			actualService1Value := []map[string]string{}

--- a/src/terraform/command_helpers_test.go
+++ b/src/terraform/command_helpers_test.go
@@ -184,7 +184,9 @@ var _ = Describe("CompileVarFlags", func() {
 			var str string
 			var actualDependencyVar []map[string]interface{}
 			err = json.Unmarshal([]byte(dependencyVar["exocom_env_vars"]), &str)
+			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal([]byte(str), &actualDependencyVar)
+			Expect(err).NotTo(HaveOccurred())
 			expectedValue := `{"web":{"receives":["users.created"],"sends":["users.create"]}}`
 			Expect(reflect.DeepEqual(actualDependencyVar[0]["value"], expectedValue)).To(BeTrue())
 		})

--- a/src/terraform/command_helpers_test.go
+++ b/src/terraform/command_helpers_test.go
@@ -23,7 +23,7 @@ func ArrayHasStringMap(haystack []map[string]string, needle map[string]string) b
 	return false
 }
 
-var _ = Describe("CompileVarFlags", func() {
+var _ = Describe("GetVarMap", func() {
 	var _ = Describe("public service with no dependencies", func() {
 		service1Config := types.ServiceConfig{
 			Type: "public",
@@ -71,12 +71,10 @@ var _ = Describe("CompileVarFlags", func() {
 		}
 
 		It("should compile the proper var flags", func() {
-			expectedDockerImageVar := map[string]string{
-				"service1_docker_image": "dummy-image1",
-				"service2_docker_image": "dummy-image2",
-			}
-			actualDockerImageVar := terraform.GetDockerImageVarMap(deployConfig, imageMap)
-			Expect(actualDockerImageVar).To(Equal(expectedDockerImageVar))
+			varMap, err := terraform.GetVarMap(deployConfig, secrets, imageMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(varMap["service1_docker_image"]).To(Equal("dummy-image1"))
+			Expect(varMap["service2_docker_image"]).To(Equal("dummy-image2"))
 
 			expectedService1EnvVars := []map[string]string{
 				{
@@ -100,11 +98,9 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "http://service2.local",
 				},
 			}
-			actualServiceEnvVars, err := terraform.GetServicesVarMap(deployConfig, secrets)
-			Expect(err).NotTo(HaveOccurred())
 			actualService1Value := []map[string]string{}
 			var escapedValue string
-			err = json.Unmarshal([]byte(actualServiceEnvVars["service1_env_vars"]), &escapedValue)
+			err = json.Unmarshal([]byte(varMap["service1_env_vars"]), &escapedValue)
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal([]byte(escapedValue), &actualService1Value)
 			Expect(err).NotTo(HaveOccurred())
@@ -136,12 +132,10 @@ var _ = Describe("CompileVarFlags", func() {
 			}
 			imageMap := map[string]string{"service1": "dummy-image", "exocom": "originate/exocom:0.0.1"}
 
-			expectedDockerImageVar := map[string]string{
-				"service1_docker_image": "dummy-image",
-				"exocom_docker_image":   "originate/exocom:0.0.1",
-			}
-			actualDockerImageVar := terraform.GetDockerImageVarMap(deployConfig, imageMap)
-			Expect(expectedDockerImageVar).To(Equal(actualDockerImageVar))
+			varMap, err := terraform.GetVarMap(deployConfig, map[string]string{}, imageMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(varMap["service1_docker_image"]).To(Equal("dummy-image"))
+			Expect(varMap["exocom_docker_image"]).To(Equal("originate/exocom:0.0.1"))
 			expectedService1EnvVars := []map[string]string{
 				{
 					"name":  "ROLE",
@@ -152,11 +146,9 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "exocom.my-app.local",
 				},
 			}
-			actualServiceEnvVars, err := terraform.GetServicesVarMap(deployConfig, map[string]string{})
-			Expect(err).NotTo(HaveOccurred())
 			actualService1Value := []map[string]string{}
 			var escapedValue string
-			err = json.Unmarshal([]byte(actualServiceEnvVars["service1_env_vars"]), &escapedValue)
+			err = json.Unmarshal([]byte(varMap["service1_env_vars"]), &escapedValue)
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal([]byte(escapedValue), &actualService1Value)
 			Expect(err).NotTo(HaveOccurred())
@@ -177,13 +169,13 @@ var _ = Describe("CompileVarFlags", func() {
 				AppContext: appContext,
 			}
 
-			dependencyVar, err := terraform.GetDependenciesVarMap(deployConfig)
+			varMap, err := terraform.GetVarMap(deployConfig, map[string]string{}, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
-			_, ok := dependencyVar["exocom_env_vars"]
+			_, ok := varMap["exocom_env_vars"]
 			Expect(ok).To(BeTrue())
 			var str string
 			var actualDependencyVar []map[string]interface{}
-			err = json.Unmarshal([]byte(dependencyVar["exocom_env_vars"]), &str)
+			err = json.Unmarshal([]byte(varMap["exocom_env_vars"]), &str)
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal([]byte(str), &actualDependencyVar)
 			Expect(err).NotTo(HaveOccurred())
@@ -232,7 +224,7 @@ var _ = Describe("CompileVarFlags", func() {
 		}
 
 		It("should add the dependency service env vars to each service", func() {
-			actualServiceEnvVars, err := terraform.GetServicesVarMap(deployConfig, map[string]string{"password-secret": "password123"})
+			varMap, err := terraform.GetVarMap(deployConfig, map[string]string{"password-secret": "password123"}, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
 			expectedService1EnvVars := []map[string]string{
 				{
@@ -258,7 +250,7 @@ var _ = Describe("CompileVarFlags", func() {
 			}
 			actualService1Value := []map[string]string{}
 			var escapedValue string
-			err = json.Unmarshal([]byte(actualServiceEnvVars["service1_env_vars"]), &escapedValue)
+			err = json.Unmarshal([]byte(varMap["service1_env_vars"]), &escapedValue)
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal([]byte(escapedValue), &actualService1Value)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/terraform/command_helpers_test.go
+++ b/src/terraform/command_helpers_test.go
@@ -75,7 +75,7 @@ var _ = Describe("CompileVarFlags", func() {
 				"service1_docker_image": "dummy-image1",
 				"service2_docker_image": "dummy-image2",
 			}
-			actualDockerImageVar := terraform.CompileDockerImageVars(deployConfig, imageMap)
+			actualDockerImageVar := terraform.GetDockerImageVarMap(deployConfig, imageMap)
 			Expect(actualDockerImageVar).To(Equal(expectedDockerImageVar))
 
 			expectedService1EnvVars := []map[string]string{
@@ -100,7 +100,7 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "http://service2.local",
 				},
 			}
-			actualServiceEnvVars, err := terraform.CompileServiceEnvVars(deployConfig, secrets)
+			actualServiceEnvVars, err := terraform.GetServicesVarMap(deployConfig, secrets)
 			Expect(err).NotTo(HaveOccurred())
 			actualService1Value := []map[string]string{}
 			var escapedValue string
@@ -140,7 +140,7 @@ var _ = Describe("CompileVarFlags", func() {
 				"service1_docker_image": "dummy-image",
 				"exocom_docker_image":   "originate/exocom:0.0.1",
 			}
-			actualDockerImageVar := terraform.CompileDockerImageVars(deployConfig, imageMap)
+			actualDockerImageVar := terraform.GetDockerImageVarMap(deployConfig, imageMap)
 			Expect(expectedDockerImageVar).To(Equal(actualDockerImageVar))
 			expectedService1EnvVars := []map[string]string{
 				{
@@ -152,7 +152,7 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "exocom.my-app.local",
 				},
 			}
-			actualServiceEnvVars, err := terraform.CompileServiceEnvVars(deployConfig, map[string]string{})
+			actualServiceEnvVars, err := terraform.GetServicesVarMap(deployConfig, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
 			actualService1Value := []map[string]string{}
 			var escapedValue string
@@ -177,7 +177,7 @@ var _ = Describe("CompileVarFlags", func() {
 				AppContext: appContext,
 			}
 
-			dependencyVar, err := terraform.CompileDependencyVars(deployConfig)
+			dependencyVar, err := terraform.GetDependenciesVarMap(deployConfig)
 			Expect(err).NotTo(HaveOccurred())
 			_, ok := dependencyVar["exocom_env_vars"]
 			Expect(ok).To(BeTrue())
@@ -232,7 +232,7 @@ var _ = Describe("CompileVarFlags", func() {
 		}
 
 		It("should add the dependency service env vars to each service", func() {
-			actualServiceEnvVars, err := terraform.CompileServiceEnvVars(deployConfig, map[string]string{"password-secret": "password123"})
+			actualServiceEnvVars, err := terraform.GetServicesVarMap(deployConfig, map[string]string{"password-secret": "password123"})
 			Expect(err).NotTo(HaveOccurred())
 			expectedService1EnvVars := []map[string]string{
 				{

--- a/src/terraform/command_helpers_test.go
+++ b/src/terraform/command_helpers_test.go
@@ -3,17 +3,25 @@ package terraform_test
 import (
 	"encoding/json"
 	"io/ioutil"
-	"strings"
+	"reflect"
 
 	"github.com/Originate/exosphere/src/terraform"
 	"github.com/Originate/exosphere/src/types"
 	"github.com/Originate/exosphere/src/types/context"
 	"github.com/Originate/exosphere/src/types/deploy"
-	"github.com/Originate/exosphere/src/util"
 	"github.com/Originate/exosphere/test/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func ArrayHasStringMap(haystack []map[string]string, needle map[string]string) bool {
+	for _, item := range haystack {
+		if reflect.DeepEqual(item, needle) {
+			return true
+		}
+	}
+	return false
+}
 
 var _ = Describe("CompileVarFlags", func() {
 	var _ = Describe("public service with no dependencies", func() {
@@ -61,15 +69,20 @@ var _ = Describe("CompileVarFlags", func() {
 				Environment: types.BuildModeEnvironmentProduction,
 			},
 		}
-		imageMap := map[string]string{"service1": "dummy-image"}
+		imageMap := map[string]string{
+			"service1": "dummy-image1",
+			"service2": "dummy-image2",
+		}
 
 		It("should compile the proper var flags", func() {
-			vars, err := terraform.CompileVarFlags(deployConfig, secrets, imageMap)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(util.DoesStringArrayContain(vars, "secret1=secret_value1"))
-			Expect(util.DoesStringArrayContain(vars, "service1_docker_image=dummy-image"))
+			expectedDockerImageVar := map[string]string{
+				"service1_docker_image": "dummy-image1",
+				"service2_docker_image": "dummy-image2",
+			}
+			actualDockerImageVar := terraform.CompileDockerImageVars(deployConfig, imageMap)
+			Expect(actualDockerImageVar).To(Equal(expectedDockerImageVar))
 
-			service1ExpectedValue := []map[string]string{
+			expectedService1EnvVars := []map[string]string{
 				{
 					"name":  "ROLE",
 					"value": "service1",
@@ -91,19 +104,17 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "http://service2.local",
 				},
 			}
-			var service1ActualString string
-			for _, varFlag := range vars {
-				if strings.Contains(varFlag, "service1_env_vars") {
-					service1ActualString = strings.Split(varFlag, "=")[1]
-				}
-			}
-			actualValue := []map[string]string{}
+			actualServiceEnvVars, err := terraform.CompileServiceEnvVars(deployConfig, secrets)
+			Expect(err).NotTo(HaveOccurred())
+			actualService1Value := []map[string]string{}
 			var escapedValue string
-			err = json.Unmarshal([]byte(service1ActualString), &escapedValue)
+			err = json.Unmarshal([]byte(actualServiceEnvVars["service1_env_vars"]), &escapedValue)
 			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal([]byte(escapedValue), &actualValue)
+			err = json.Unmarshal([]byte(escapedValue), &actualService1Value)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(service1ExpectedValue).To(ConsistOf(actualValue))
+			for _, actualEnvVar := range actualService1Value {
+				Expect(ArrayHasStringMap(expectedService1EnvVars, actualEnvVar)).To(BeTrue())
+			}
 		})
 	})
 
@@ -129,19 +140,13 @@ var _ = Describe("CompileVarFlags", func() {
 			}
 			imageMap := map[string]string{"service1": "dummy-image", "exocom": "originate/exocom:0.0.1"}
 
-			vars, err := terraform.CompileVarFlags(deployConfig, map[string]string{}, imageMap)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vars[2]).To(Equal("-var"))
-			exocomVarFlag := strings.Split(vars[3], "=")[0]
-			exocomDockerImageName := strings.Split(vars[3], "=")[1]
-			Expect(exocomVarFlag).To(Equal("exocom_docker_image"))
-			Expect(exocomDockerImageName).To(Equal("originate/exocom:0.0.1"))
-			Expect(vars[4]).To(Equal("-var"))
-			varName := strings.Split(vars[5], "=")[0]
-			varVal := strings.Split(vars[5], "=")[1]
-			var escapedVal string
-			actualVal := []map[string]string{}
-			expectedVal := []map[string]string{
+			expectedDockerImageVar := map[string]string{
+				"service1_docker_image": "dummy-image",
+				"exocom_docker_image":   "originate/exocom:0.0.1",
+			}
+			actualDockerImageVar := terraform.CompileDockerImageVars(deployConfig, imageMap)
+			Expect(expectedDockerImageVar).To(Equal(actualDockerImageVar))
+			expectedService1EnvVars := []map[string]string{
 				{
 					"name":  "ROLE",
 					"value": "service1",
@@ -151,12 +156,17 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "exocom.my-app.local",
 				},
 			}
-			err = json.Unmarshal([]byte(varVal), &escapedVal)
+			actualServiceEnvVars, err := terraform.CompileServiceEnvVars(deployConfig, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal([]byte(escapedVal), &actualVal)
+			actualService1Value := []map[string]string{}
+			var escapedValue string
+			err = json.Unmarshal([]byte(actualServiceEnvVars["service1_env_vars"]), &escapedValue)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(varName).To(Equal("service1_env_vars"))
-			Expect(expectedVal).To(ConsistOf(actualVal))
+			err = json.Unmarshal([]byte(escapedValue), &actualService1Value)
+			Expect(err).NotTo(HaveOccurred())
+			for _, actualEnvVar := range actualService1Value {
+				Expect(ArrayHasStringMap(expectedService1EnvVars, actualEnvVar)).To(BeTrue())
+			}
 		})
 
 		It("should compile the dependency terraform vars", func() {
@@ -171,28 +181,16 @@ var _ = Describe("CompileVarFlags", func() {
 				AppContext: appContext,
 			}
 
-			vars, err := terraform.CompileVarFlags(deployConfig, map[string]string{}, map[string]string{})
+			dependencyVar, err := terraform.CompileDependencyVars(deployConfig)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vars[4]).To(Equal("-var"))
-			varFlagName := strings.Split(vars[7], "=")[0]
-			varFlagValue := strings.Split(vars[7], "=")[1]
-			var escapedFlagValue1 string
-			var escapedFlagValue2 []map[string]string
-			var actualValue string
+			_, ok := dependencyVar["exocom_env_vars"]
+			Expect(ok).To(BeTrue())
+			var str string
+			var actualDependencyVar []map[string]interface{}
+			err = json.Unmarshal([]byte(dependencyVar["exocom_env_vars"]), &str)
+			err = json.Unmarshal([]byte(str), &actualDependencyVar)
 			expectedValue := `{"web":{"receives":["users.created"],"sends":["users.create"]}}`
-
-			err = json.Unmarshal([]byte(varFlagValue), &escapedFlagValue1)
-			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal([]byte(escapedFlagValue1), &escapedFlagValue2)
-			Expect(err).NotTo(HaveOccurred())
-			for k, v := range escapedFlagValue2[0] {
-				if k == "value" {
-					actualValue = v
-				}
-			}
-
-			Expect(varFlagName).To(Equal("exocom_env_vars"))
-			Expect(actualValue).To(Equal(expectedValue))
+			Expect(reflect.DeepEqual(actualDependencyVar[0]["value"], expectedValue)).To(BeTrue())
 		})
 	})
 
@@ -234,17 +232,11 @@ var _ = Describe("CompileVarFlags", func() {
 				},
 			},
 		}
-		imageMap := map[string]string{"service1": "dummy-image"}
 
 		It("should add the dependency service env vars to each service", func() {
-			vars, err := terraform.CompileVarFlags(deployConfig, map[string]string{"password-secret": "password123"}, imageMap)
+			actualServiceEnvVars, err := terraform.CompileServiceEnvVars(deployConfig, map[string]string{"password-secret": "password123"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vars[6]).To(Equal("-var"))
-			varName := strings.Split(vars[7], "=")[0]
-			varVal := strings.Split(vars[7], "=")[1]
-			var escapedVal string
-			actualVal := []map[string]string{}
-			expectedVal := []map[string]string{
+			expectedService1EnvVars := []map[string]string{
 				{
 					"name":  "DB_PASS",
 					"value": "password123",
@@ -266,12 +258,15 @@ var _ = Describe("CompileVarFlags", func() {
 					"value": "service1",
 				},
 			}
-			err = json.Unmarshal([]byte(varVal), &escapedVal)
+			actualService1Value := []map[string]string{}
+			var escapedValue string
+			err = json.Unmarshal([]byte(actualServiceEnvVars["service1_env_vars"]), &escapedValue)
 			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal([]byte(escapedVal), &actualVal)
+			err = json.Unmarshal([]byte(escapedValue), &actualService1Value)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(varName).To(Equal("service1_env_vars"))
-			Expect(expectedVal).To(ConsistOf(actualVal))
+			for _, actualEnvVar := range actualService1Value {
+				Expect(ArrayHasStringMap(expectedService1EnvVars, actualEnvVar)).To(BeTrue())
+			}
 		})
 	})
 })

--- a/src/types/app_remote_config.go
+++ b/src/types/app_remote_config.go
@@ -8,6 +8,8 @@ import (
 // AppRemoteConfig represents production specific configuration for an application
 type AppRemoteConfig struct {
 	Dependencies      map[string]RemoteDependency
+	Environment       map[string]string
+	Secrets           []string
 	URL               string `yaml:",omitempty"`
 	Region            string `yaml:",omitempty"`
 	AccountID         string `yaml:"account-id,omitempty"`


### PR DESCRIPTION
This is so that we can move forward with extracting remote dependencies. Local app-wide env vars still need to be managed: https://github.com/Originate/exosphere/issues/886