### PR TITLE
[extract production dependencies 5] Build docker images

### DIFF
--- a/src/application/deployer/helpers.go
+++ b/src/application/deployer/helpers.go
@@ -3,46 +3,18 @@ package deployer
 import (
 	"fmt"
 
-	"github.com/Originate/exosphere/src/config"
 	"github.com/Originate/exosphere/src/types"
 	"github.com/Originate/exosphere/src/types/deploy"
 )
 
-// GetImageNames returns a mapping from service/dependency names to image name on the user's machine
-func GetImageNames(deployConfig deploy.Config, dockerCompose types.DockerCompose) (map[string]string, error) {
-	images := getServiceImageNames(deployConfig, dockerCompose)
-	dependencyImages, err := getDependencyImageNames(deployConfig)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range dependencyImages {
-		images[k] = v
-	}
-	return images, nil
-}
-
-func getServiceImageNames(deployConfig deploy.Config, dockerCompose types.DockerCompose) map[string]string {
+// GetServiceImageNames returns a mapping from service names to image name on the user's machine
+func GetServiceImageNames(deployConfig deploy.Config, dockerCompose types.DockerCompose) map[string]string {
 	images := map[string]string{}
 	for _, serviceRole := range deployConfig.AppContext.Config.GetSortedServiceRoles() {
 		dockerConfig := dockerCompose.Services[serviceRole]
 		images[serviceRole] = buildImageName(dockerConfig, deployConfig.GetDockerComposeProjectName(), serviceRole)
 	}
 	return images
-}
-
-func getDependencyImageNames(deployConfig deploy.Config) (map[string]string, error) {
-	dependencies := config.GetBuiltRemoteDependencies(deployConfig.AppContext)
-	images := map[string]string{}
-	for dependencyName, dependency := range dependencies {
-		if dependency.HasDockerConfig() {
-			dockerConfig, err := dependency.GetDockerConfig()
-			if err != nil {
-				return nil, err
-			}
-			images[dependencyName] = buildImageName(dockerConfig, deployConfig.GetDockerComposeProjectName(), dependencyName)
-		}
-	}
-	return images, nil
 }
 
 func buildImageName(dockerConfig types.DockerConfig, dockerComposeProjectName, serviceRole string) string {

--- a/src/application/deployer/helpers_test.go
+++ b/src/application/deployer/helpers_test.go
@@ -14,8 +14,8 @@ import (
 
 var _ = Describe("Deployer helpers", func() {
 
-	var _ = Describe("GetImageNames", func() {
-		It("compiles the list of image names", func() {
+	var _ = Describe("GetServiceImageNames", func() {
+		It("compiles the list of service image names", func() {
 			appDir, err := ioutil.TempDir("", "")
 			Expect(err).NotTo(HaveOccurred())
 			err = helpers.CheckoutApp(appDir, "test")
@@ -33,10 +33,9 @@ var _ = Describe("Deployer helpers", func() {
 			deployConfig := deploy.Config{
 				AppContext: appContext,
 			}
-			imageNames, err := deployer.GetImageNames(deployConfig, dockerCompose)
+			imageNames := deployer.GetServiceImageNames(deployConfig, dockerCompose)
 			Expect(err).NotTo(HaveOccurred())
 			expectedImages := map[string]string{
-				"exocom":    "originate/exocom:0.27.0",
 				"users":     "test_users",
 				"dashboard": "test_dashboard",
 				"web":       "test_web",

--- a/src/application/deployer/push_application_images.go
+++ b/src/application/deployer/push_application_images.go
@@ -24,10 +24,7 @@ func PushApplicationImages(deployConfig deploy.Config) (map[string]string, error
 	if err != nil {
 		return nil, err
 	}
-	imagesMap, err := GetImageNames(deployConfig, dockerCompose)
-	if err != nil {
-		return nil, err
-	}
+	imagesMap := GetServiceImageNames(deployConfig, dockerCompose)
 	serviceData := deployConfig.AppContext.Config.Services
 	for serviceRole, imageName := range imagesMap {
 		taggedImage, err := PushImage(PushImageOptions{


### PR DESCRIPTION
Resolving #751

Docker images are now defined directly in `dependency.tf` themselves, only the `{{version}}` field needs to be populated. 