### PR TITLE
release 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+
+## 0.34.0 (2017-12-18)
+
+Fixes versioning from previous release (should have been major release)
+
+#### Bug Fixes
+* Fix required fields for RDS dependency
+
 ## 0.33.3 (2017-12-18)
 
 #### BREAKING CHANGES

--- a/src/version.go
+++ b/src/version.go
@@ -1,4 +1,4 @@
 package src
 
 // Version exports the current Exosphere Version
-const Version = "0.33.3"
+const Version = "0.34.0"


### PR DESCRIPTION
The fact that we had to release a new version to update dependency plugins probably means we should move that stuff to their own repo