### PR TITLE
cleanup unneeded build modes

### DIFF
--- a/src/application/deployer/push_application_images.go
+++ b/src/application/deployer/push_application_images.go
@@ -20,7 +20,7 @@ func PushApplicationImages(deployConfig deploy.Config) (map[string]string, error
 	if err != nil {
 		return nil, err
 	}
-	dockerCompose, err := tools.GetDockerCompose(path.Join(deployConfig.AppContext.GetDockerComposeDir(), types.BuildModeDeploy.GetDockerComposeFileName()))
+	dockerCompose, err := tools.GetDockerCompose(path.Join(deployConfig.AppContext.GetDockerComposeDir(), types.LocalProductionComposeFileName))
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,6 @@ func PushApplicationImages(deployConfig deploy.Config) (map[string]string, error
 			ImageName:       imageName,
 			ServiceRole:     serviceRole,
 			ServiceLocation: serviceData[serviceRole].Location,
-			BuildMode:       types.BuildModeDeploy,
 		})
 		if err != nil {
 			return nil, err

--- a/src/application/deployer/push_image.go
+++ b/src/application/deployer/push_image.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Originate/exosphere/src/aws"
 	"github.com/Originate/exosphere/src/docker/compose"
 	"github.com/Originate/exosphere/src/docker/tools"
+	"github.com/Originate/exosphere/src/types"
 )
 
 // PushImage pushes a single service/dependency image to ECR, building or pulling if needed
@@ -43,7 +44,7 @@ func PushImage(options PushImageOptions) (string, error) {
 func buildOrPullImage(options PushImageOptions) error {
 	opts := compose.CommandOptions{
 		DockerComposeDir:      options.DeployConfig.AppContext.GetDockerComposeDir(),
-		DockerComposeFileName: options.BuildMode.GetDockerComposeFileName(),
+		DockerComposeFileName: types.LocalProductionComposeFileName,
 		Writer:                options.DeployConfig.Writer,
 		Env: []string{
 			fmt.Sprintf("COMPOSE_PROJECT_NAME=%s", options.DeployConfig.GetDockerComposeProjectName()),

--- a/src/application/deployer/push_image_options.go
+++ b/src/application/deployer/push_image_options.go
@@ -1,7 +1,6 @@
 package deployer
 
 import (
-	"github.com/Originate/exosphere/src/types"
 	"github.com/Originate/exosphere/src/types/deploy"
 	"github.com/aws/aws-sdk-go/service/ecr"
 )
@@ -15,5 +14,4 @@ type PushImageOptions struct {
 	ServiceLocation string
 	ServiceRole     string
 	BuildImage      bool
-	BuildMode       types.BuildMode
 }

--- a/src/application/runner/index.go
+++ b/src/application/runner/index.go
@@ -18,7 +18,7 @@ func Run(options RunOptions) error {
 	util.Merge(envVars, buildSecretEnvVars(options.AppContext))
 	runOptions := composerunner.RunOptions{
 		DockerComposeDir:      options.AppContext.GetDockerComposeDir(),
-		DockerComposeFileName: options.BuildMode.GetDockerComposeFileName(),
+		DockerComposeFileName: options.DockerComposeFileName,
 		Writer:                options.Writer,
 		EnvironmentVariables:  envVars,
 	}

--- a/src/application/runner/run_options.go
+++ b/src/application/runner/run_options.go
@@ -3,14 +3,13 @@ package runner
 import (
 	"io"
 
-	"github.com/Originate/exosphere/src/types"
 	"github.com/Originate/exosphere/src/types/context"
 )
 
 // RunOptions runs the overall application
 type RunOptions struct {
 	AppContext               *context.AppContext
+	DockerComposeFileName    string
 	DockerComposeProjectName string
 	Writer                   io.Writer
-	BuildMode                types.BuildMode
 }

--- a/src/application/tester/test_runner.go
+++ b/src/application/tester/test_runner.go
@@ -19,10 +19,9 @@ type TestRunner struct {
 }
 
 // NewTestRunner is TestRunner's constructor
-func NewTestRunner(appContext *context.AppContext, writer io.Writer, mode types.BuildMode) (*TestRunner, error) {
+func NewTestRunner(appContext *context.AppContext, writer io.Writer) (*TestRunner, error) {
 	tester := &TestRunner{
 		AppContext: appContext,
-		BuildMode:  mode,
 		Writer:     writer,
 	}
 	var err error
@@ -54,7 +53,7 @@ func (s *TestRunner) getRunOptions() (composerunner.RunOptions, error) {
 	dockerComposeProjectName := composebuilder.GetTestDockerComposeProjectName(s.AppContext.Config.Name)
 	return composerunner.RunOptions{
 		DockerComposeDir:      s.AppContext.GetDockerComposeDir(),
-		DockerComposeFileName: s.BuildMode.GetDockerComposeFileName(),
+		DockerComposeFileName: types.LocalTestComposeFileName,
 		Writer:                s.Writer,
 		AbortOnExit:           true,
 		EnvironmentVariables: map[string]string{

--- a/src/application/tester/tester.go
+++ b/src/application/tester/tester.go
@@ -12,10 +12,10 @@ import (
 
 // TestApp runs the tests for the entire application and return true if the tests passed
 // and an error if any
-func TestApp(appContext *context.AppContext, writer io.Writer, mode types.BuildMode, shutdown chan os.Signal) (types.TestResult, error) {
+func TestApp(appContext *context.AppContext, writer io.Writer, shutdown chan os.Signal) (types.TestResult, error) {
 	failedTests := []string{}
 	locations := []string{}
-	testRunner, err := NewTestRunner(appContext, writer, mode)
+	testRunner, err := NewTestRunner(appContext, writer)
 	if err != nil {
 		return types.TestResult{}, err
 	}
@@ -72,8 +72,8 @@ func printResults(failedTests []string, writer io.Writer) error {
 
 // TestService runs the tests for the service and return true if the tests passed
 // and an error if any
-func TestService(serviceContext *context.ServiceContext, writer io.Writer, mode types.BuildMode, shutdown chan os.Signal) (types.TestResult, error) {
-	testRunner, err := NewTestRunner(serviceContext.AppContext, writer, mode)
+func TestService(serviceContext *context.ServiceContext, writer io.Writer, shutdown chan os.Signal) (types.TestResult, error) {
+	testRunner, err := NewTestRunner(serviceContext.AppContext, writer)
 	if err != nil {
 		return types.TestResult{}, err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -26,7 +26,7 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		dockerComposeFileName := types.LocalProductionComposeFileName
+		dockerComposeFileName := types.LocalDevelopmentComposeFileName
 		if productionFlag {
 			dockerComposeFileName = types.LocalProductionComposeFileName
 		}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -26,17 +26,13 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		buildMode := types.BuildMode{
-			Type:        types.BuildModeTypeLocal,
-			Mount:       true,
-			Environment: types.BuildModeEnvironmentDevelopment,
-		}
+		dockerComposeFileName := types.LocalProductionComposeFileName
 		if productionFlag {
-			buildMode.Environment = types.BuildModeEnvironmentProduction
+			dockerComposeFileName = types.LocalProductionComposeFileName
 		}
 		err = runner.Run(runner.RunOptions{
 			AppContext:               userContext.AppContext,
-			BuildMode:                buildMode,
+			DockerComposeFileName:    dockerComposeFileName,
 			DockerComposeProjectName: composebuilder.GetDockerComposeProjectName(userContext.AppContext.Config.Name),
 			Writer: os.Stdout,
 		})

--- a/src/cmd/test.go
+++ b/src/cmd/test.go
@@ -25,17 +25,13 @@ var testCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		writer := os.Stdout
-		buildMode := types.BuildMode{
-			Type:        types.BuildModeTypeLocal,
-			Environment: types.BuildModeEnvironmentTest,
-		}
 		shutdownChannel := make(chan os.Signal, 1)
 		signal.Notify(shutdownChannel, os.Interrupt)
 		var testResult types.TestResult
 		if userContext.HasServiceContext {
-			testResult, err = tester.TestService(userContext.ServiceContext, writer, buildMode, shutdownChannel)
+			testResult, err = tester.TestService(userContext.ServiceContext, writer, shutdownChannel)
 		} else {
-			testResult, err = tester.TestApp(userContext.AppContext, writer, buildMode, shutdownChannel)
+			testResult, err = tester.TestApp(userContext.AppContext, writer, shutdownChannel)
 		}
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
We had some build modes left over that we were only using for getting the docker compose filenames. Since the building is all done by `exo generate`, we didn't need these anymore and could use the filenames directly instead. 