### PR TITLE
Remove unneeded docker image var

### DIFF
--- a/src/terraform/command_helpers.go
+++ b/src/terraform/command_helpers.go
@@ -53,9 +53,6 @@ func getDockerImageVarMap(deployConfig deploy.Config, imagesMap map[string]strin
 			dockerImages[fmt.Sprintf("%s_docker_image", dependencyName)] = imagesMap[dependencyName]
 		}
 	}
-	for dependencyName := range deployConfig.AppContext.Config.Remote.Dependencies {
-		dockerImages[fmt.Sprintf("%s_docker_image", dependencyName)] = imagesMap[dependencyName]
-	}
 	return dockerImages
 }
 

--- a/src/terraform/command_helpers_test.go
+++ b/src/terraform/command_helpers_test.go
@@ -153,12 +153,11 @@ var _ = Describe("GetVarMap", func() {
 				},
 				RemoteEnvironmentID: "qa",
 			}
-			imageMap := map[string]string{"service1": "dummy-image", "exocom": "originate/exocom:0.0.1"}
+			imageMap := map[string]string{"service1": "dummy-image"}
 
 			varMap, err := terraform.GetVarMap(deployConfig, map[string]string{}, imageMap)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(varMap["service1_docker_image"]).To(Equal("dummy-image"))
-			Expect(varMap["exocom_docker_image"]).To(Equal("originate/exocom:0.0.1"))
 			expectedService1EnvVars := []map[string]string{
 				{
 					"name":  "ROLE",


### PR DESCRIPTION
Dependencies define their own docker image, and the version is passed in through `template-config`. Besides, there weren't any entries in `imageMap` for dependencies so this would always generate a blank var: `"exocom_docker_image": ""`