### PR TITLE
exo-run: Catch manual shutdown error message

### DIFF
--- a/src/application/runner/index.go
+++ b/src/application/runner/index.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"strings"
 
 	"github.com/Originate/exosphere/src/docker/composerunner"
 	"github.com/Originate/exosphere/src/types/context"
@@ -42,6 +43,9 @@ func Run(options RunOptions) error {
 	}()
 	<-doneChannel
 	_ = composerunner.Shutdown(runOptions)
+	if strings.Contains(err.Error(), "exit status") {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
I think we had this check in before, did we take it out for a reason? It may have been hiding actual important exo run errors